### PR TITLE
Improve the AMQP protocol test framework.

### DIFF
--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpConnection.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpConnection.java
@@ -99,7 +99,10 @@ public class AmqpConnection extends AmqpCommandDecoder implements ServerMethodPr
                     clientProperties, mechanism, locale);
         }
         assertState(ConnectionState.AWAIT_START_OK);
-
+        AMQMethodBody responseBody = this.methodRegistry.createConnectionSecureBody(new byte[0]);
+        writeFrame(responseBody.generateFrame(0));
+        state = ConnectionState.AWAIT_SECURE_OK;
+        bufferSender.flush();
     }
 
     @Override

--- a/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/AmqpChannelMethodTest.java
+++ b/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/AmqpChannelMethodTest.java
@@ -1,0 +1,38 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.amqp.test;
+
+import org.apache.qpid.server.protocol.v0_8.AMQShortString;
+import org.apache.qpid.server.protocol.v0_8.transport.AMQBody;
+import org.apache.qpid.server.protocol.v0_8.transport.BasicGetBody;
+import org.apache.qpid.server.protocol.v0_8.transport.BasicGetOkBody;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Unit tests for AMQP channel level methods.
+ */
+public class AmqpChannelMethodTest extends AmqpProtocolTestBase {
+
+    @Test
+    public void testBasicGet() {
+        BasicGetBody cmd = methodRegistry.createBasicGetBody(1, AMQShortString.createAMQShortString("test"), false);
+        cmd.generateFrame(1).writePayload(toServerSender);
+        toServerSender.flush();
+        AMQBody response = (AMQBody) clientChannel.poll();
+        Assert.assertTrue(response instanceof BasicGetOkBody);
+        BasicGetOkBody basicGetOkBody = (BasicGetOkBody) response;
+        Assert.assertEquals(basicGetOkBody.getMessageCount(), 100);
+    }
+}

--- a/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/AmqpConnectionMethodTest.java
+++ b/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/AmqpConnectionMethodTest.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.amqp.test;
+
+import lombok.extern.log4j.Log4j2;
+import org.apache.qpid.server.protocol.v0_8.AMQShortString;
+import org.apache.qpid.server.protocol.v0_8.transport.AMQBody;
+import org.apache.qpid.server.protocol.v0_8.transport.ConnectionSecureBody;
+import org.apache.qpid.server.protocol.v0_8.transport.ConnectionStartOkBody;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Unit test for AMQP connection level methods.
+ */
+@Log4j2
+public class AmqpConnectionMethodTest extends AmqpProtocolTestBase {
+
+    @Test
+    public void testConnectionStartOk() {
+        ConnectionStartOkBody cmd = methodRegistry.createConnectionStartOkBody(null,
+                AMQShortString.createAMQShortString(""), new byte[0], AMQShortString.createAMQShortString("en_US"));
+        cmd.generateFrame(0).writePayload(toServerSender);
+        toServerSender.flush();
+        AMQBody response = (AMQBody) clientChannel.poll();
+        Assert.assertTrue(response instanceof ConnectionSecureBody);
+    }
+}

--- a/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/frame/AmqpClientChannel.java
+++ b/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/frame/AmqpClientChannel.java
@@ -15,24 +15,23 @@ package io.streamnative.pulsar.handlers.amqp.test.frame;
 
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
-import org.apache.qpid.server.protocol.v0_8.transport.AMQMethodBody;
 
 /**
  * Amqp client channel for receive responses from server.
  */
 public class AmqpClientChannel {
 
-    private final BlockingQueue<AMQMethodBody> responses;
+    private final BlockingQueue<Object> responses;
 
     public AmqpClientChannel() {
         this.responses = new LinkedBlockingQueue<>();
     }
 
-    public void add(AMQMethodBody response) {
+    public void add(Object response) {
         responses.add(response);
     }
 
-    public AMQMethodBody poll() {
+    public Object poll() {
         return responses.poll();
     }
 }

--- a/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/frame/AmqpClientChannelMethodProcessor.java
+++ b/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/frame/AmqpClientChannelMethodProcessor.java
@@ -19,6 +19,9 @@ import org.apache.qpid.server.protocol.v0_8.AMQShortString;
 import org.apache.qpid.server.protocol.v0_8.FieldTable;
 import org.apache.qpid.server.protocol.v0_8.transport.BasicContentHeaderProperties;
 import org.apache.qpid.server.protocol.v0_8.transport.ClientChannelMethodProcessor;
+import org.apache.qpid.server.protocol.v0_8.transport.ConfirmSelectOkBody;
+import org.apache.qpid.server.protocol.v0_8.transport.ContentBody;
+import org.apache.qpid.server.protocol.v0_8.transport.ContentHeaderBody;
 
 /**
  * Client channel level method processor for testing.
@@ -34,89 +37,161 @@ public class AmqpClientChannelMethodProcessor implements ClientChannelMethodProc
 
     @Override
     public void receiveChannelOpenOk() {
-
+        if (log.isDebugEnabled()) {
+            log.debug("[RECEIVE CHANNEL OPEN OK]");
+        }
+        clientMethodProcessor.clientChannel.add(clientMethodProcessor.methodRegistry.createChannelOpenOkBody());
     }
 
     @Override
     public void receiveChannelAlert(int replyCode, AMQShortString replyText, FieldTable details) {
-
+        if (log.isDebugEnabled()) {
+            log.debug("[RECEIVE CHANNEL ALERT - replyCode {} - replyText {} - details {}]", replyCode, replyText,
+                    details);
+        }
+        clientMethodProcessor.clientChannel.add(
+                clientMethodProcessor.methodRegistry.createChannelAlertBody(replyCode, replyText, details));
     }
 
     @Override
     public void receiveAccessRequestOk(int ticket) {
-
+        if (log.isDebugEnabled()) {
+            log.debug("[RECEIVE ACCESS REQUEST OK] - ticket {}", ticket);
+        }
+        clientMethodProcessor.clientChannel.add(
+                clientMethodProcessor.methodRegistry.createAccessRequestOkBody(ticket));
     }
 
     @Override
     public void receiveExchangeDeclareOk() {
-
+        if (log.isDebugEnabled()) {
+            log.debug("[RECEIVE EXCHANGE DECLARE OK]");
+        }
+        clientMethodProcessor.clientChannel.add(
+                clientMethodProcessor.methodRegistry.createExchangeDeclareOkBody());
     }
 
     @Override
     public void receiveExchangeDeleteOk() {
-
+        if (log.isDebugEnabled()) {
+            log.debug("[RECEIVE EXCHANGE DELETE OK]");
+        }
+        clientMethodProcessor.clientChannel.add(
+                clientMethodProcessor.methodRegistry.createExchangeDeleteOkBody());
     }
 
     @Override
     public void receiveExchangeBoundOk(int replyCode, AMQShortString replyText) {
-
+        if (log.isDebugEnabled()) {
+            log.debug("[RECEIVE EXCHANGE BOUND OK] - replyCode {} - replyText {}", replyCode, replyText);
+        }
+        clientMethodProcessor.clientChannel.add(
+                clientMethodProcessor.methodRegistry.createExchangeBoundOkBody(replyCode, replyText));
     }
 
     @Override
     public void receiveQueueBindOk() {
-
+        if (log.isDebugEnabled()) {
+            log.debug("[RECEIVE QUEUE BIND OK]");
+        }
+        clientMethodProcessor.clientChannel.add(
+                clientMethodProcessor.methodRegistry.createQueueBindOkBody());
     }
 
     @Override
     public void receiveQueueUnbindOk() {
-
+        if (log.isDebugEnabled()) {
+            log.debug("[RECEIVE QUEUE UNBIND OK]");
+        }
+        clientMethodProcessor.clientChannel.add(
+                clientMethodProcessor.methodRegistry.createQueueUnbindOkBody());
     }
 
     @Override
     public void receiveQueueDeclareOk(AMQShortString queue, long messageCount, long consumerCount) {
-
+        if (log.isDebugEnabled()) {
+            log.debug("[RECEIVE QUEUE DECLARE OK] - queue {} - messageCount {} - consumerCount {}", queue,
+                    messageCount, consumerCount);
+        }
+        clientMethodProcessor.clientChannel.add(
+                clientMethodProcessor.methodRegistry.createQueueDeclareOkBody(queue, messageCount, consumerCount));
     }
 
     @Override
     public void receiveQueuePurgeOk(long messageCount) {
-
+        if (log.isDebugEnabled()) {
+            log.debug("[RECEIVE QUEUE PURGE OK] - messageCount {}", messageCount);
+        }
+        clientMethodProcessor.clientChannel.add(
+                clientMethodProcessor.methodRegistry.createQueuePurgeOkBody(messageCount));
     }
 
     @Override
     public void receiveQueueDeleteOk(long messageCount) {
-
+        if (log.isDebugEnabled()) {
+            log.debug("[RECEIVE QUEUE DELETE OK] - messageCount {}", messageCount);
+        }
+        clientMethodProcessor.clientChannel.add(
+                clientMethodProcessor.methodRegistry.createQueueDeleteOkBody(messageCount));
     }
 
     @Override
     public void receiveBasicRecoverSyncOk() {
-
+        if (log.isDebugEnabled()) {
+            log.debug("[RECEIVE BASIC RECOVER SYNC OK]");
+        }
+        clientMethodProcessor.clientChannel.add(
+                clientMethodProcessor.methodRegistry.createBasicRecoverSyncOkBody());
     }
 
     @Override
     public void receiveBasicQosOk() {
-
+        if (log.isDebugEnabled()) {
+            log.debug("[RECEIVE BASIC QOS OK]");
+        }
+        clientMethodProcessor.clientChannel.add(
+                clientMethodProcessor.methodRegistry.createBasicQosOkBody());
     }
 
     @Override
     public void receiveBasicConsumeOk(AMQShortString consumerTag) {
-
+        if (log.isDebugEnabled()) {
+            log.debug("[RECEIVE BASIC CONSUME OK] - consumerTag {}", consumerTag);
+        }
+        clientMethodProcessor.clientChannel.add(
+                clientMethodProcessor.methodRegistry.createBasicConsumeOkBody(consumerTag));
     }
 
     @Override
     public void receiveBasicCancelOk(AMQShortString consumerTag) {
-
+        if (log.isDebugEnabled()) {
+            log.debug("[RECEIVE BASIC CANCEL OK] - consumerTag {}", consumerTag);
+        }
+        clientMethodProcessor.clientChannel.add(
+                clientMethodProcessor.methodRegistry.createBasicCancelOkBody(consumerTag));
     }
 
     @Override
     public void receiveBasicReturn(int replyCode, AMQShortString replyText, AMQShortString exchange,
                                    AMQShortString routingKey) {
-
+        if (log.isDebugEnabled()) {
+            log.debug("[RECEIVE BASIC RETURN] - replyCode {} - replyText {} - exchange {} - routingKey {}",
+                    replyCode, replyText, exchange, routingKey);
+        }
+        clientMethodProcessor.clientChannel.add(
+                clientMethodProcessor.methodRegistry.createBasicReturnBody(replyCode, replyText, exchange, routingKey));
     }
 
     @Override
     public void receiveBasicDeliver(AMQShortString consumerTag, long deliveryTag, boolean redelivered,
                                     AMQShortString exchange, AMQShortString routingKey) {
-
+        if (log.isDebugEnabled()) {
+            log.debug("[RECEIVE BASIC DELIVER] - consumerTag {} - deliveryTag {} - redelivered {} - exchange {} "
+                    + "- routingKey {}", consumerTag, deliveryTag, redelivered, exchange, routingKey);
+        }
+        clientMethodProcessor.clientChannel.add(
+                clientMethodProcessor.methodRegistry.createBasicDeliverBody(consumerTag, deliveryTag, redelivered,
+                        exchange, routingKey));
     }
 
     @Override
@@ -133,57 +208,93 @@ public class AmqpClientChannelMethodProcessor implements ClientChannelMethodProc
 
     @Override
     public void receiveBasicGetEmpty() {
-
+        if (log.isDebugEnabled()) {
+            log.debug("[RECEIVE BASIC GET EMPTY]");
+        }
+        clientMethodProcessor.clientChannel.add(clientMethodProcessor.methodRegistry.
+                createBasicGetEmptyBody(AMQShortString.EMPTY_STRING));
     }
 
     @Override
     public void receiveTxSelectOk() {
-
+        if (log.isDebugEnabled()) {
+            log.debug("[RECEIVE TX SELECT OK]");
+        }
+        clientMethodProcessor.clientChannel.add(clientMethodProcessor.methodRegistry.createTxSelectOkBody());
     }
 
     @Override
     public void receiveTxCommitOk() {
-
+        if (log.isDebugEnabled()) {
+            log.debug("[RECEIVE TX COMMIT OK]");
+        }
+        clientMethodProcessor.clientChannel.add(clientMethodProcessor.methodRegistry.createTxCommitOkBody());
     }
 
     @Override
     public void receiveTxRollbackOk() {
-
+        if (log.isDebugEnabled()) {
+            log.debug("[RECEIVE TX ROLLBACK OK]");
+        }
+        clientMethodProcessor.clientChannel.add(clientMethodProcessor.methodRegistry.createTxRollbackOkBody());
     }
 
     @Override
     public void receiveConfirmSelectOk() {
-
+        if (log.isDebugEnabled()) {
+            log.debug("[RECEIVE CONFIRM SELECT OK]");
+        }
+        clientMethodProcessor.clientChannel.add(ConfirmSelectOkBody.INSTANCE);
     }
 
     @Override
     public void receiveChannelFlow(boolean active) {
-
+        if (log.isDebugEnabled()) {
+            log.debug("[RECEIVE CHANNEL FLOW] - active {}", active);
+        }
+        clientMethodProcessor.clientChannel.add(clientMethodProcessor.methodRegistry.createChannelFlowBody(active));
     }
 
     @Override
     public void receiveChannelFlowOk(boolean active) {
-
+        if (log.isDebugEnabled()) {
+            log.debug("[RECEIVE CHANNEL FLOW OK] - active {}", active);
+        }
+        clientMethodProcessor.clientChannel.add(clientMethodProcessor.methodRegistry.createChannelFlowOkBody(active));
     }
 
     @Override
     public void receiveChannelClose(int replyCode, AMQShortString replyText, int classId, int methodId) {
-
+        if (log.isDebugEnabled()) {
+            log.debug("[RECEIVE CHANNEL CLOSE] - replyCode {} - replyText {} - classId {} - methodId {}",
+                    replyCode, replyText, classId, methodId);
+        }
+        clientMethodProcessor.clientChannel.add(clientMethodProcessor.methodRegistry.createChannelCloseBody(replyCode,
+                replyText, classId, methodId));
     }
 
     @Override
     public void receiveChannelCloseOk() {
-
+        if (log.isDebugEnabled()) {
+            log.debug("[RECEIVE CHANNEL CLOSE OK]");
+        }
+        clientMethodProcessor.clientChannel.add(clientMethodProcessor.methodRegistry.createChannelCloseOkBody());
     }
 
     @Override
     public void receiveMessageContent(QpidByteBuffer data) {
-
+        if (log.isDebugEnabled()) {
+            log.debug("[RECEIVE MESSAGE CONTENT] - size {}", data.remaining());
+        }
+        clientMethodProcessor.clientChannel.add(new ContentBody(data));
     }
 
     @Override
     public void receiveMessageHeader(BasicContentHeaderProperties properties, long bodySize) {
-
+        if (log.isDebugEnabled()) {
+            log.debug("[RECEIVE MESSAGE HEADER] - properties {} - bodySize {}", properties, bodySize);
+        }
+        clientMethodProcessor.clientChannel.add(new ContentHeaderBody(properties, bodySize));
     }
 
     @Override
@@ -193,11 +304,16 @@ public class AmqpClientChannelMethodProcessor implements ClientChannelMethodProc
 
     @Override
     public void receiveBasicNack(long deliveryTag, boolean multiple, boolean requeue) {
-
+        if (log.isDebugEnabled()) {
+            log.debug("[RECEIVE BASIC NACK] - deliveryTag {} - multiple {} - requeue {}", deliveryTag, multiple,
+                    requeue);
+        }
     }
 
     @Override
     public void receiveBasicAck(long deliveryTag, boolean multiple) {
-
+        if (log.isDebugEnabled()) {
+            log.debug("[RECEIVE BASIC ACK] - deliveryTag {} - multiple {}", deliveryTag, multiple);
+        }
     }
 }

--- a/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/frame/AmqpClientMethodProcessor.java
+++ b/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/frame/AmqpClientMethodProcessor.java
@@ -18,6 +18,7 @@ import org.apache.qpid.server.protocol.ProtocolVersion;
 import org.apache.qpid.server.protocol.v0_8.AMQShortString;
 import org.apache.qpid.server.protocol.v0_8.FieldTable;
 import org.apache.qpid.server.protocol.v0_8.transport.ClientMethodProcessor;
+import org.apache.qpid.server.protocol.v0_8.transport.HeartbeatBody;
 import org.apache.qpid.server.protocol.v0_8.transport.MethodRegistry;
 import org.apache.qpid.server.protocol.v0_8.transport.ProtocolInitiation;
 
@@ -40,7 +41,7 @@ public class AmqpClientMethodProcessor implements ClientMethodProcessor<AmqpClie
     public void receiveConnectionStart(short versionMajor, short versionMinor, FieldTable serverProperties,
                                        byte[] mechanisms, byte[] locales) {
         if (log.isDebugEnabled()) {
-            log.debug("[RECEIVE CONNECTION OPEN OK] - version major {} - version minor {}", versionMajor,
+            log.debug("[RECEIVE CONNECTION START] - version major {} - version minor {}", versionMajor,
                     versionMinor);
         }
         clientChannel.add(methodRegistry.createConnectionStartBody(versionMajor, versionMinor, serverProperties,
@@ -49,27 +50,40 @@ public class AmqpClientMethodProcessor implements ClientMethodProcessor<AmqpClie
 
     @Override
     public void receiveConnectionSecure(byte[] challenge) {
-
+        if (log.isDebugEnabled()) {
+            log.debug("[RECEIVE CONNECTION SECURE] - challenge {}", challenge);
+        }
+        clientChannel.add(methodRegistry.createConnectionSecureBody(challenge));
     }
 
     @Override
     public void receiveConnectionRedirect(AMQShortString host, AMQShortString knownHosts) {
-
+        if (log.isDebugEnabled()) {
+            log.debug("[RECEIVE CONNECTION REDIRECT] - host {} - knownHosts {}", host, knownHosts);
+        }
+        clientChannel.add(methodRegistry.createConnectionRedirectBody(host, knownHosts));
     }
 
     @Override
     public void receiveConnectionTune(int channelMax, long frameMax, int heartbeat) {
-
+        if (log.isDebugEnabled()) {
+            log.debug("[RECEIVE CONNECTION TUNE] - channelMax {} - frameMax {} - heartbeat {}", channelMax,
+                    frameMax, heartbeat);
+        }
+        clientChannel.add(methodRegistry.createConnectionTuneBody(channelMax, frameMax, heartbeat));
     }
 
     @Override
     public void receiveConnectionOpenOk(AMQShortString knownHosts) {
-
+        if (log.isDebugEnabled()) {
+            log.debug("[RECEIVE CONNECTION OPEN OK] - knownHosts {}", knownHosts);
+        }
+        clientChannel.add(methodRegistry.createConnectionOpenOkBody(knownHosts));
     }
 
     @Override
     public ProtocolVersion getProtocolVersion() {
-        return null;
+        return ProtocolVersion.v0_91;
     }
 
     @Override
@@ -79,22 +93,35 @@ public class AmqpClientMethodProcessor implements ClientMethodProcessor<AmqpClie
 
     @Override
     public void receiveConnectionClose(int replyCode, AMQShortString replyText, int classId, int methodId) {
-
+        if (log.isDebugEnabled()) {
+            log.debug("[RECEIVE CONNECTION CLOSE] - replyCode {} - replyText {} - classId {} - methodId {}",
+                    replyCode, replyText, classId, methodId);
+        }
+        clientChannel.add(methodRegistry.createConnectionCloseBody(replyCode, replyText, classId, methodId));
     }
 
     @Override
     public void receiveConnectionCloseOk() {
-
+        if (log.isDebugEnabled()) {
+            log.debug("[RECEIVE CONNECTION CLOSE OK]");
+        }
+        clientChannel.add(methodRegistry.createConnectionCloseOkBody());
     }
 
     @Override
     public void receiveHeartbeat() {
-
+        if (log.isDebugEnabled()) {
+            log.debug("[RECEIVE HEARTBEAT]");
+        }
+        clientChannel.add(new HeartbeatBody());
     }
 
     @Override
     public void receiveProtocolHeader(ProtocolInitiation protocolInitiation) {
-
+        if (log.isDebugEnabled()) {
+            log.debug("[RECEIVE PROTOCOL HEADER] - {}", protocolInitiation);
+        }
+        clientChannel.add(protocolInitiation);
     }
 
     @Override


### PR DESCRIPTION
### Motivation
Improve the AMQP protocol test framework. Using the test protocol test framework can do server-client interaction unit tests for  AMQP connection/channel easier.

Using the test framework:
1. Create a unit test class to extends the `AmqpProtocolTestBase`.
2. Create the AMQP body for the test request.
3. Using `toServerSender` to sends the request to the server.
4. Using `clientChannel ` to get responses from the server

### Changes
- Add `AmqpProtocolTestBase.java` to init required components for the AMQP connection and channel unit tests. 
- Split AMQP connection unit tests and AMQP channel unit tests into two test classes.
- Implement all AMQP methods of the client processor. The processor sends the decoded response to the client channel so that the unit test can get the decoded response simple.