### PR TITLE
Handle remaining buffer in the AmqpBrokerDecoder

### DIFF
--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/RabbitmqTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/RabbitmqTest.java
@@ -146,7 +146,7 @@ public class RabbitmqTest extends AmqpProtocolHandlerTestBase {
 
         final String queueName = "testQueue";
         final String message = "Hello AOP!";
-        final int messagesNum = 10;
+        final int messagesNum = 1000;
 
         @Cleanup
         PulsarAdmin pulsarAdmin = PulsarAdmin.builder().serviceHttpUrl("http://127.0.0.1:"


### PR DESCRIPTION
Fixes #41

### Motivation

Handle remaining buffer in the AmqpBrokerDecoder

### Verifying this change

Update the basicPublishTest() to send more messages.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)
