### PR TITLE
Support Default Vhost In Proxy

### DIFF
--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpConnection.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpConnection.java
@@ -72,7 +72,7 @@ public class AmqpConnection extends AmqpCommandDecoder implements ServerMethodPr
         OPEN
     }
 
-    private static final String DEFAULT_NAMESPACE = "default";
+    public static final String DEFAULT_NAMESPACE = "default";
 
     private static final AtomicLong ID_GENERATOR = new AtomicLong(0);
 

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/proxy/ProxyConnection.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/proxy/ProxyConnection.java
@@ -24,6 +24,7 @@ import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
 import io.streamnative.pulsar.handlers.amqp.AmqpBrokerDecoder;
+import io.streamnative.pulsar.handlers.amqp.AmqpConnection;
 import io.streamnative.pulsar.handlers.amqp.AmqpProtocolHandler;
 import java.util.ArrayList;
 import java.util.List;
@@ -225,6 +226,9 @@ public class ProxyConnection extends ChannelInboundHandlerAdapter implements
         String virtualHostStr = AMQShortString.toString(virtualHost);
         if ((virtualHostStr != null) && virtualHostStr.charAt(0) == '/') {
             virtualHostStr = virtualHostStr.substring(1);
+            if (org.apache.commons.lang.StringUtils.isEmpty(virtualHostStr)){
+                virtualHostStr = AmqpConnection.DEFAULT_NAMESPACE;
+            }
         }
         vhost = virtualHostStr;
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/RabbitMQTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/RabbitMQTestBase.java
@@ -139,7 +139,7 @@ public class RabbitMQTestBase extends AmqpProtocolHandlerTestBase {
                             sendMsgCnt.incrementAndGet();
                         } else if (isBundleUnload.get()) {
                             // send message until consumer get enough messages
-                            // TODO If add send confirm, only send expected messages is enough
+                            // Add send confirm, only send expected messages is enough
                             channel.basicPublish(exchangeName, "", null, contentMsg.getBytes());
                             sendMsgCnt.incrementAndGet();
                             Thread.sleep(10);
@@ -174,6 +174,11 @@ public class RabbitMQTestBase extends AmqpProtocolHandlerTestBase {
                                            byte[] body) throws IOException {
                     String message = new String(body, "UTF-8");
                     Assert.assertEquals(message, contentMsg);
+                    if (bundleUnloadTest && totalReceiveMsgCnt.get() == expectedMsgCntPerQueue * queueList.size()) {
+                        // If test is bundleUnloadTest, stop totalReceiveMsgCnt
+                        // when totalReceiveMsgCnt reach the expectedCount
+                        return;
+                    }
                     totalReceiveMsgCnt.incrementAndGet();
                     countDownLatch.countDown();
                 }


### PR DESCRIPTION
### Motivation

Currently, if the client use empty vhost to create a connection with proxy service, the proxy service can't process it.

### Modifications

If the connection vhost is empty, use the default namespace `default`, same with AmqpConnection.

Fix proxy test.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change added tests and can be verified as follows:

unit test

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)