### PR TITLE
Fix get defaultExchange failed when the default exchange not init completed.

### DIFF
--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpChannel.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpChannel.java
@@ -1030,7 +1030,7 @@ public class AmqpChannel implements ServerChannelMethodProcessor {
                                         }
 
                                     } else {
-                                        log.error("publish message error {}", throwable.getMessage());
+                                        log.error("publish message error {}", throwable1.getMessage());
                                     }
                                 });
 

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpProtocolHandler.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpProtocolHandler.java
@@ -86,8 +86,8 @@ public class AmqpProtocolHandler implements ProtocolHandler {
     public void start(BrokerService service) {
         brokerService = service;
 
-        ConnectionContainer.init(brokerService.getPulsar());
         ExchangeContainer.init(brokerService.getPulsar());
+        ConnectionContainer.init(brokerService.getPulsar());
 
         if (amqpConfig.isAmqpProxyEnable()) {
             ProxyConfiguration proxyConfig = new ProxyConfiguration();

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpProtocolHandler.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpProtocolHandler.java
@@ -86,7 +86,7 @@ public class AmqpProtocolHandler implements ProtocolHandler {
     public void start(BrokerService service) {
         brokerService = service;
 
-        ExchangeContainer.init(brokerService.getPulsar());
+        ExchangeContainer.init();
         ConnectionContainer.init(brokerService.getPulsar());
 
         if (amqpConfig.isAmqpProxyEnable()) {

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/ConnectionContainer.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/ConnectionContainer.java
@@ -42,6 +42,7 @@ public class ConnectionContainer {
             @Override
             public void onLoad(NamespaceBundle namespaceBundle) {
                 log.info("ConnectionContainer [onLoad] namespaceBundle: {}", namespaceBundle);
+                ExchangeContainer.pulsarService = pulsarService;
                 ExchangeContainer.initBuildInExchange(namespaceBundle.getNamespaceObject());
             }
 

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/ConnectionContainer.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/ConnectionContainer.java
@@ -42,8 +42,7 @@ public class ConnectionContainer {
             @Override
             public void onLoad(NamespaceBundle namespaceBundle) {
                 log.info("ConnectionContainer [onLoad] namespaceBundle: {}", namespaceBundle);
-                ExchangeContainer.pulsarService = pulsarService;
-                ExchangeContainer.initBuildInExchange(namespaceBundle.getNamespaceObject());
+                ExchangeContainer.initBuildInExchange(pulsarService, namespaceBundle.getNamespaceObject());
             }
 
             @Override

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/ExchangeContainer.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/ExchangeContainer.java
@@ -19,6 +19,8 @@ import io.streamnative.pulsar.handlers.amqp.impl.PersistentExchange;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -36,6 +38,7 @@ public class ExchangeContainer {
 
     private static final Map<String, AmqpExchange.Type> BUILDIN_EXCHANGE_NAME_SET = new HashMap<>();
     private static PulsarService pulsarService;
+    private static CountDownLatch countDownLatch;
 
     public static void init(PulsarService pulsarService) {
         if (ExchangeContainer.pulsarService == null) {
@@ -44,6 +47,7 @@ public class ExchangeContainer {
             BUILDIN_EXCHANGE_NAME_SET.put(ExchangeDefaults.DIRECT_EXCHANGE_NAME, AmqpExchange.Type.Direct);
             BUILDIN_EXCHANGE_NAME_SET.put(ExchangeDefaults.FANOUT_EXCHANGE_NAME, AmqpExchange.Type.Fanout);
             BUILDIN_EXCHANGE_NAME_SET.put(ExchangeDefaults.TOPIC_EXCHANGE_NAME, AmqpExchange.Type.Topic);
+            countDownLatch = new CountDownLatch(BUILDIN_EXCHANGE_NAME_SET.size());
         }
     }
 
@@ -62,6 +66,14 @@ public class ExchangeContainer {
     }
 
     public static AmqpExchange getExchange(NamespaceName namespaceName, String exchangeName) {
+        if (exchangeName.equals(AbstractAmqpExchange.DEFAULT_EXCHANGE_DURABLE)) {
+            try {
+                countDownLatch.await(2, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                log.error("Default exchanges init timeout. ");
+                return null;
+            }
+        }
         if (namespaceName == null || StringUtils.isEmpty(exchangeName)) {
             return null;
         }
@@ -100,6 +112,7 @@ public class ExchangeContainer {
             ExchangeContainer.putExchange(namespaceName, exchangeName,
                     new PersistentExchange(exchangeName, exchangeType,
                             (PersistentTopic) topic, false));
+            countDownLatch.countDown();
         });
     }
 

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/ExchangeContainer.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/ExchangeContainer.java
@@ -66,7 +66,8 @@ public class ExchangeContainer {
     }
 
     public static AmqpExchange getExchange(NamespaceName namespaceName, String exchangeName) {
-        if (exchangeName.equals(AbstractAmqpExchange.DEFAULT_EXCHANGE_DURABLE)) {
+        if (exchangeName.equals(AbstractAmqpExchange.DEFAULT_EXCHANGE_DURABLE) &&
+                countDownLatch != null) {
             try {
                 countDownLatch.await(2, TimeUnit.SECONDS);
             } catch (InterruptedException e) {

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/ExchangeContainer.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/ExchangeContainer.java
@@ -1,12 +1,15 @@
 /**
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package io.streamnative.pulsar.handlers.amqp;

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/ExchangeContainer.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/ExchangeContainer.java
@@ -66,8 +66,8 @@ public class ExchangeContainer {
     }
 
     public static AmqpExchange getExchange(NamespaceName namespaceName, String exchangeName) {
-        if (exchangeName.equals(AbstractAmqpExchange.DEFAULT_EXCHANGE_DURABLE) &&
-                countDownLatch != null) {
+        if (BUILDIN_EXCHANGE_NAME_SET.containsKey(exchangeName)
+                && countDownLatch != null) {
             try {
                 countDownLatch.await(2, TimeUnit.SECONDS);
             } catch (InterruptedException e) {

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/ExchangeContainer.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/ExchangeContainer.java
@@ -72,7 +72,7 @@ public class ExchangeContainer {
             } catch (InterruptedException e) {
                 log.error("Default exchanges init timeout. ");
                 return null;
-            }finally {
+            } finally {
                 countDownLatchMap.remove(namespaceName);
             }
         }

--- a/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/AmqpChannelMethodTest.java
+++ b/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/AmqpChannelMethodTest.java
@@ -181,12 +181,12 @@ public class AmqpChannelMethodTest extends AmqpProtocolTestBase {
         cmd.generateFrame(1).writePayload(toServerSender);
         toServerSender.flush();
 
+        AMQBody response = (AMQBody) clientChannel.poll();
+        Assert.assertTrue(response instanceof ExchangeDeclareOkBody);
+
         ExchangeDeleteBody cmd1 = methodRegistry.createExchangeDeleteBody(0, exchange, false, true);
         cmd1.generateFrame(1).writePayload(toServerSender);
         toServerSender.flush();
-
-        AMQBody response = (AMQBody) clientChannel.poll();
-        Assert.assertTrue(response instanceof ExchangeDeclareOkBody);
 
         AMQBody response1 = (AMQBody) clientChannel.poll();
         Assert.assertTrue(response1 instanceof ExchangeDeleteOkBody);
@@ -227,20 +227,19 @@ public class AmqpChannelMethodTest extends AmqpProtocolTestBase {
         Mockito.when(connection.getPulsarService().getState()).thenReturn(PulsarService.State.Started);
 
         exchangeDeclare(exchange, exchangeIsDurable);
+        toServerSender.flush();
+        AMQBody response = (AMQBody) clientChannel.poll();
+        Assert.assertTrue(response instanceof ExchangeDeclareOkBody);
 
         queueDeclare(queue, queueIsDurable);
+        toServerSender.flush();
+        response = (AMQBody) clientChannel.poll();
+        Assert.assertTrue(response instanceof QueueDeclareOkBody);
 
         QueueBindBody cmd = methodRegistry.createQueueBindBody(0, queue, exchange, "key",
             false, null);
         cmd.generateFrame(1).writePayload(toServerSender);
         toServerSender.flush();
-
-        AMQBody response = (AMQBody) clientChannel.poll();
-        Assert.assertTrue(response instanceof ExchangeDeclareOkBody);
-
-        response = (AMQBody) clientChannel.poll();
-        Assert.assertTrue(response instanceof QueueDeclareOkBody);
-
         response = (AMQBody) clientChannel.poll();
         Assert.assertTrue(response instanceof QueueBindOkBody);
         count++;

--- a/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/AmqpChannelMethodTest.java
+++ b/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/AmqpChannelMethodTest.java
@@ -156,14 +156,13 @@ public class AmqpChannelMethodTest extends AmqpProtocolTestBase {
                 false, false, false, null);
         cmd1.generateFrame(1).writePayload(toServerSender);
         toServerSender.flush();
+        AMQBody response = (AMQBody) clientChannel.poll();
+        Assert.assertTrue(response instanceof QueueDeclareOkBody);
 
         QueueDeclareBody cmd2 = methodRegistry.createQueueDeclareBody(0, "queue", true, true,
                 false, false, false, null);
         cmd2.generateFrame(1).writePayload(toServerSender);
         toServerSender.flush();
-
-        AMQBody response = (AMQBody) clientChannel.poll();
-        Assert.assertTrue(response instanceof QueueDeclareOkBody);
 
         response = (AMQBody) clientChannel.poll();
         Assert.assertTrue(response instanceof QueueDeclareOkBody);
@@ -283,21 +282,21 @@ public class AmqpChannelMethodTest extends AmqpProtocolTestBase {
         List<String> subs = new ArrayList<>();
         subs.add(exchange);
         exchangeDeclare(exchange, true);
+        toServerSender.flush();
+        AMQBody response = (AMQBody) clientChannel.poll();
+        Assert.assertTrue(response instanceof ExchangeDeclareOkBody);
+
         queueDeclare(queue, true);
+        toServerSender.flush();
+        AMQBody response1 = (AMQBody) clientChannel.poll();
+        Assert.assertTrue(response1 instanceof QueueDeclareOkBody);
 
         QueueUnbindBody cmd = methodRegistry.createQueueUnbindBody(0, AMQShortString.createAMQShortString(queue),
             AMQShortString.createAMQShortString(exchange), AMQShortString.createAMQShortString("key"), null);
         cmd.generateFrame(1).writePayload(toServerSender);
         toServerSender.flush();
-
-        AMQBody response = (AMQBody) clientChannel.poll();
-        Assert.assertTrue(response instanceof ExchangeDeclareOkBody);
-
-        response = (AMQBody) clientChannel.poll();
-        Assert.assertTrue(response instanceof QueueDeclareOkBody);
-
-        response = (AMQBody) clientChannel.poll();
-        Assert.assertTrue(response instanceof QueueUnbindOkBody);
+        AMQBody response2 = (AMQBody) clientChannel.poll();
+        Assert.assertTrue(response2 instanceof QueueUnbindOkBody);
     }
 
     @Test

--- a/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/frame/AmqpClientChannel.java
+++ b/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/frame/AmqpClientChannel.java
@@ -32,7 +32,7 @@ public class AmqpClientChannel {
     }
 
     public Object poll() {
-        int count = 5;
+        int count = 3;
         Object object = responses.poll();
         while (object == null && count > 0) {
             try {

--- a/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/frame/AmqpClientChannel.java
+++ b/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/frame/AmqpClientChannel.java
@@ -32,6 +32,17 @@ public class AmqpClientChannel {
     }
 
     public Object poll() {
-        return responses.poll();
+        int count = 3;
+        Object object = responses.poll();
+        while (object == null && count > 0) {
+            try {
+                Thread.sleep(10);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+            object = responses.poll();
+            count--;
+        }
+        return object;
     }
 }

--- a/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/frame/AmqpClientChannel.java
+++ b/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/frame/AmqpClientChannel.java
@@ -36,7 +36,7 @@ public class AmqpClientChannel {
         Object object = responses.poll();
         while (object == null && count > 0) {
             try {
-                Thread.sleep(10);
+                Thread.sleep(100);
             } catch (InterruptedException e) {
                 e.printStackTrace();
             }

--- a/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/frame/AmqpClientChannel.java
+++ b/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/frame/AmqpClientChannel.java
@@ -32,7 +32,7 @@ public class AmqpClientChannel {
     }
 
     public Object poll() {
-        int count = 3;
+        int count = 5;
         Object object = responses.poll();
         while (object == null && count > 0) {
             try {


### PR DESCRIPTION
### Motivation

In some unit tests, default exchange not init completed when call getExchange. 

### Modifications

Add CountDownLatch in ExchangeContainer.java to take control of default exchange init and get.

### Verifying this change
Pass the exist unit tests.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

  - Does this pull request introduce a new feature? (no)