### PR TITLE
[build] Update checkstyle to v 8.29

### DIFF
--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpChannel.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpChannel.java
@@ -16,6 +16,7 @@ package io.streamnative.pulsar.handlers.amqp;
 import static org.apache.qpid.server.protocol.ErrorCodes.INTERNAL_ERROR;
 import static org.apache.qpid.server.protocol.ErrorCodes.NOT_FOUND;
 import static org.apache.qpid.server.transport.util.Functions.hex;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -454,7 +455,7 @@ public class AmqpChannel implements ServerChannelMethodProcessor {
             closeChannel(ErrorCodes.NOT_FOUND, "No such exchange: '" + exchange + "'");
             return;
         }
-        if (exchangeName.equals(AbstractAmqpExchange.DEFAULT_EXCHANGE_DURABLE)){
+        if (exchangeName.equals(AbstractAmqpExchange.DEFAULT_EXCHANGE_DURABLE)) {
             closeChannel(ErrorCodes.ACCESS_REFUSED, "Can not bind to default exchange ");
             return;
         }
@@ -580,7 +581,6 @@ public class AmqpChannel implements ServerChannelMethodProcessor {
             }
         }
     }
-
 
 
     @Override
@@ -914,7 +914,6 @@ public class AmqpChannel implements ServerChannelMethodProcessor {
             MessagePublishInfo info = currentMessage.getMessagePublishInfo();
             String routingKey = AMQShortString.toString(info.getRoutingKey());
             String exchangeName = AMQShortString.toString(info.getExchange());
-
 
             Message<byte[]> message;
             try {

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/IndexMessage.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/IndexMessage.java
@@ -16,7 +16,6 @@ package io.streamnative.pulsar.handlers.amqp;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.util.Recycler;
-
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/UnacknowledgedMessageMap.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/UnacknowledgedMessageMap.java
@@ -12,7 +12,9 @@
  * limitations under the License.
  */
 package io.streamnative.pulsar.handlers.amqp;
+
 import static com.google.common.base.Preconditions.checkNotNull;
+
 import com.google.common.annotations.VisibleForTesting;
 import java.util.Collection;
 import java.util.Collections;
@@ -22,7 +24,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.bookkeeper.mledger.Position;
-
 
 
 /**
@@ -59,7 +60,6 @@ public class UnacknowledgedMessageMap {
 
     private final Map<Long, MessageConsumerAssociation> map = new ConcurrentHashMap<>();
     private final AmqpChannel channel;
-
     public UnacknowledgedMessageMap(AmqpChannel channel) {
         this.channel = channel;
     }

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/frame/types/ShortString.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/frame/types/ShortString.java
@@ -15,7 +15,6 @@ package io.streamnative.pulsar.handlers.amqp.frame.types;
 
 import static java.lang.String.format;
 
-
 import io.netty.buffer.ByteBuf;
 import java.nio.charset.Charset;
 

--- a/amqp-impl/src/main/java/org/apache/qpid/server/bytebuffer/MultiQpidByteBuffer.java
+++ b/amqp-impl/src/main/java/org/apache/qpid/server/bytebuffer/MultiQpidByteBuffer.java
@@ -17,7 +17,6 @@ import com.google.common.primitives.Chars;
 import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;
 import com.google.common.primitives.Shorts;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.BufferOverflowException;

--- a/amqp-impl/src/main/java/org/apache/qpid/server/bytebuffer/QpidByteBuffer.java
+++ b/amqp-impl/src/main/java/org/apache/qpid/server/bytebuffer/QpidByteBuffer.java
@@ -14,19 +14,17 @@
 package org.apache.qpid.server.bytebuffer;
 
 import io.netty.channel.ChannelHandlerContext;
-
-import javax.net.ssl.SSLEngine;
-import javax.net.ssl.SSLEngineResult;
-import javax.net.ssl.SSLException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
-import java.nio.channels.Channel;
 import java.nio.channels.GatheringByteChannel;
 import java.nio.channels.ScatteringByteChannel;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.ThreadFactory;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLEngineResult;
+import javax.net.ssl.SSLException;
 
 public interface QpidByteBuffer extends AutoCloseable
 {

--- a/amqp-impl/src/main/java/org/apache/qpid/server/bytebuffer/QpidByteBufferFactory.java
+++ b/amqp-impl/src/main/java/org/apache/qpid/server/bytebuffer/QpidByteBufferFactory.java
@@ -16,15 +16,10 @@ package org.apache.qpid.server.bytebuffer;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
-
-import javax.net.ssl.SSLEngine;
-import javax.net.ssl.SSLEngineResult;
-import javax.net.ssl.SSLException;
 import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
-import java.nio.channels.Channel;
 import java.nio.channels.GatheringByteChannel;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -35,6 +30,9 @@ import java.util.List;
 import java.util.concurrent.ThreadFactory;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLEngineResult;
+import javax.net.ssl.SSLException;
 
 final class QpidByteBufferFactory
 {

--- a/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/mock/MockManagedLedger.java
+++ b/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/mock/MockManagedLedger.java
@@ -17,7 +17,6 @@ package io.streamnative.pulsar.handlers.amqp.test.mock;
 import io.netty.buffer.ByteBuf;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-
 import org.apache.bookkeeper.mledger.AsyncCallbacks;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.ManagedLedger;
@@ -31,6 +30,7 @@ import org.apache.pulsar.common.api.proto.PulsarApi;
  * ManagedLedger mock test.
  */
 public class MockManagedLedger implements ManagedLedger {
+
     @Override
     public String getName() {
         return null;

--- a/pom.xml
+++ b/pom.xml
@@ -265,6 +265,7 @@
             <encoding>UTF-8</encoding>
             <consoleOutput>true</consoleOutput>
             <failsOnError>true</failsOnError>
+            <!-- enable this to fail on "WARNING"s -->
             <!--<violationSeverity>warning</violationSeverity>-->
             <!--<failOnViolation>true</failOnViolation>-->
             <includeResources>false</includeResources>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     <!-- plugin dependencies -->
     <dockerfile-maven.version>1.4.9</dockerfile-maven.version>
     <license-maven-plugin.version>3.0.rc1</license-maven-plugin.version>
-    <maven-checkstyle-plugin.version>3.0.0</maven-checkstyle-plugin.version>
+    <maven-checkstyle-plugin.version>3.1.1</maven-checkstyle-plugin.version>
     <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
     <maven-surefire-plugin.version>3.0.0-M1</maven-surefire-plugin.version>
     <os-maven-plugin.version>1.4.1.Final</os-maven-plugin.version>
@@ -263,7 +263,9 @@
             <suppressionsLocation>resources/suppressions.xml</suppressionsLocation>
             <encoding>UTF-8</encoding>
             <consoleOutput>true</consoleOutput>
-            <failOnViolation>true</failOnViolation>
+            <failsOnError>true</failsOnError>
+            <!--<violationSeverity>warning</violationSeverity>-->
+            <!--<failOnViolation>true</failOnViolation>-->
             <includeResources>false</includeResources>
             <includeTestSourceDirectory>true</includeTestSourceDirectory>
           </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -261,6 +261,7 @@
           <configuration>
             <configLocation>resources/checkstyle.xml</configLocation>
             <suppressionsLocation>resources/suppressions.xml</suppressionsLocation>
+            <linkXRef>false</linkXRef>
             <encoding>UTF-8</encoding>
             <consoleOutput>true</consoleOutput>
             <failsOnError>true</failsOnError>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
     <maven-surefire-plugin.version>3.0.0-M1</maven-surefire-plugin.version>
     <os-maven-plugin.version>1.4.1.Final</os-maven-plugin.version>
-    <puppycrawl.checkstyle.version>6.19</puppycrawl.checkstyle.version>
+    <puppycrawl.checkstyle.version>8.29</puppycrawl.checkstyle.version>
     <spotbugs-maven-plugin.version>3.1.8</spotbugs-maven-plugin.version>
     <qpid-protocol-plugin.version>7.1.8</qpid-protocol-plugin.version>
     <rabbitmq.version>5.8.0</rabbitmq.version>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <log4j2.version>2.10.0</log4j2.version>
     <lombok.version>1.18.4</lombok.version>
     <mockito.version>2.22.0</mockito.version>
-    <pulsar.version>2.6.0-SNAPSHOT</pulsar.version>
+    <pulsar.version>2.6.0</pulsar.version>
     <slf4j.version>1.7.25</slf4j.version>
     <spotbugs-annotations.version>3.1.8</spotbugs-annotations.version>
     <testcontainers.version>1.12.5</testcontainers.version>

--- a/resources/checkstyle.xml
+++ b/resources/checkstyle.xml
@@ -53,11 +53,6 @@ page at http://checkstyle.sourceforge.net/config.html -->
     </module>
 
     <!-- Allow use of comment to suppress javadocstyle -->
-    <module name="SuppressionCommentFilter">
-        <property name="offCommentFormat" value="CHECKSTYLE.OFF\: ([\w\|]+)"/>
-        <property name="onCommentFormat" value="CHECKSTYLE.ON\: ([\w\|]+)"/>
-        <property name="checkFormat" value="$1"/>
-    </module>
     <module name="SuppressionFilter">
         <property name="file" value="${checkstyle.suppressions.file}" default="suppressions.xml" />
     </module>
@@ -67,6 +62,13 @@ page at http://checkstyle.sourceforge.net/config.html -->
 
     <!-- All Java AST specific tests live under TreeWalker module. -->
     <module name="TreeWalker">
+
+        <!-- Allow use of comment to suppress javadocstyle -->
+        <module name="SuppressionCommentFilter">
+            <property name="offCommentFormat" value="CHECKSTYLE.OFF\: ([\w\|]+)"/>
+            <property name="onCommentFormat" value="CHECKSTYLE.ON\: ([\w\|]+)"/>
+            <property name="checkFormat" value="$1"/>
+        </module>
 
         <module name="TodoComment">
             <!-- Checks that disallowed strings are not used in comments.  -->
@@ -88,6 +90,7 @@ page at http://checkstyle.sourceforge.net/config.html -->
 
         <module name="ImportOrder">
             <property name="severity" value="error"/>
+            <property name="separated" value="true"/>
             <!-- This ensures that static imports go first. -->
             <property name="option" value="top"/>
             <property name="sortStaticImportsAlphabetically" value="true"/>
@@ -145,16 +148,14 @@ page at http://checkstyle.sourceforge.net/config.html -->
         <module name="JavadocMethod">
             <property name="scope" value="protected"/>
             <property name="severity" value="error"/>
-            <property name="allowMissingJavadoc" value="true"/>
             <property name="allowMissingParamTags" value="true"/>
             <property name="allowMissingReturnTag" value="true"/>
-            <property name="allowMissingThrowsTags" value="true"/>
-            <property name="allowThrowsTagsForSubclasses" value="true"/>
-            <property name="allowUndeclaredRTE" value="true"/>
         </module>
 
         <!-- Check that paragraph tags are used correctly in Javadoc. -->
-        <module name="JavadocParagraph"/>
+        <!-- This module causes all the license comments to fail. -->
+        <!-- TODO: Either leave this commented out (or remove it), or put <p> tags in the license files -->
+        <!-- <module name="JavadocParagraph"/> -->
 
         <module name="JavadocType">
             <property name="scope" value="protected"/>
@@ -274,24 +275,9 @@ page at http://checkstyle.sourceforge.net/config.html -->
 
         <!--
 
-        LENGTH and CODING CHECKS
+        CODING CHECKS
 
         -->
-
-        <module name="LineLength">
-            <!-- Checks if a line is too long. -->
-            <property name="max" value="120"/>
-            <property name="severity" value="error"/>
-
-            <!--
-              The default ignore pattern exempts the following elements:
-                - import statements
-                - long URLs inside comments
-            -->
-
-            <property name="ignorePattern"
-                      value="^(package .*;\s*)|(import .*;\s*)|( *\* .*https?://.*)$"/>
-        </module>
 
         <module name="LeftCurly">
             <!-- Checks for placement of the left curly brace ('{'). -->
@@ -433,8 +419,22 @@ page at http://checkstyle.sourceforge.net/config.html -->
             <property name="severity" value="error"/>
         </module>
 
-        <!-- Required to support SuppressWarningsComment -->
-        <module name="FileContentsHolder"/>
-
     </module>
+
+    <!-- LENGTH CHECKS -->
+    <module name="LineLength">
+        <!-- Checks if a line is too long. -->
+        <property name="max" value="120"/>
+        <property name="severity" value="error"/>
+
+        <!--
+          The default ignore pattern exempts the following elements:
+            - import statements
+            - long URLs inside comments
+        -->
+
+        <property name="ignorePattern"
+            value="^(package .*;\s*)|(import .*;\s*)|( *\* .*https?://.*)$"/>
+    </module>
+
 </module>

--- a/tests/src/test/java/com/rabbitmq/client/test/BrokerTestCase.java
+++ b/tests/src/test/java/com/rabbitmq/client/test/BrokerTestCase.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
+
 import com.google.common.collect.Sets;
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.AlreadyClosedException;

--- a/tests/src/test/java/com/rabbitmq/client/test/TestUtils.java
+++ b/tests/src/test/java/com/rabbitmq/client/test/TestUtils.java
@@ -16,6 +16,7 @@
 package com.rabbitmq.client.test;
 
 import static org.junit.Assert.assertTrue;
+
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.Connection;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/AmqpProtocolHandlerTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/AmqpProtocolHandlerTestBase.java
@@ -19,7 +19,6 @@ import static org.mockito.Mockito.spy;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.net.URI;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/AbstractRejectTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/AbstractRejectTest.java
@@ -13,9 +13,11 @@
  */
 
 package io.streamnative.pulsar.handlers.amqp.rabbitmq.functional;
+
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.AssertJUnit.assertTrue;
+
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.Envelope;
 import com.rabbitmq.client.GetResponse;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/AlternateExchange.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/AlternateExchange.java
@@ -15,6 +15,7 @@
 package io.streamnative.pulsar.handlers.amqp.rabbitmq.functional;
 
 import static org.junit.Assert.assertEquals;
+
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.GetResponse;
 import com.rabbitmq.client.ReturnListener;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/BasicConsume.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/BasicConsume.java
@@ -15,6 +15,7 @@
 package io.streamnative.pulsar.handlers.amqp.rabbitmq.functional;
 
 import static org.junit.Assert.assertTrue;
+
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.DefaultConsumer;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/BasicGet.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/BasicGet.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
 import com.rabbitmq.client.AlreadyClosedException;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.test.BrokerTestCase;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/BindingLifecycle.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/BindingLifecycle.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.GetResponse;
 import java.io.IOException;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/BindingLifecycleBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/BindingLifecycleBase.java
@@ -19,6 +19,7 @@ package io.streamnative.pulsar.handlers.amqp.rabbitmq.functional;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
+
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.GetResponse;
 import com.rabbitmq.client.test.QueueingConsumer;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/CcRoutes.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/CcRoutes.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
+
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.AMQP.BasicProperties;
 import com.rabbitmq.client.GetResponse;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/Confirm.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/Confirm.java
@@ -17,6 +17,7 @@
 package io.streamnative.pulsar.handlers.amqp.rabbitmq.functional;
 
 import static org.junit.Assert.fail;
+
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.ConfirmListener;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/ConnectionOpen.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/ConnectionOpen.java
@@ -18,6 +18,7 @@ package io.streamnative.pulsar.handlers.amqp.rabbitmq.functional;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.ConnectionFactory;
 import com.rabbitmq.client.MalformedFrameException;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/ConnectionRecovery.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/ConnectionRecovery.java
@@ -17,6 +17,7 @@ package io.streamnative.pulsar.handlers.amqp.rabbitmq.functional;
 import static com.rabbitmq.client.test.TestUtils.prepareForRecovery;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
+
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.AMQP.BasicProperties;
 import com.rabbitmq.client.Address;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/ConsumerCancelNotification.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/ConsumerCancelNotification.java
@@ -17,6 +17,7 @@ package io.streamnative.pulsar.handlers.amqp.rabbitmq.functional;
 
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.Consumer;
 import com.rabbitmq.client.DefaultConsumer;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/ConsumerCount.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/ConsumerCount.java
@@ -17,6 +17,7 @@
 package io.streamnative.pulsar.handlers.amqp.rabbitmq.functional;
 
 import static org.junit.Assert.assertEquals;
+
 import com.rabbitmq.client.DefaultConsumer;
 import com.rabbitmq.client.test.BrokerTestCase;
 import java.io.IOException;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/ConsumerPriorities.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/ConsumerPriorities.java
@@ -19,6 +19,7 @@ package io.streamnative.pulsar.handlers.amqp.rabbitmq.functional;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.DefaultConsumer;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/DeadLetterExchange.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/DeadLetterExchange.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.AMQP.BasicProperties;
 import com.rabbitmq.client.Channel;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/DefaultExchange.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/DefaultExchange.java
@@ -17,6 +17,7 @@
 package io.streamnative.pulsar.handlers.amqp.rabbitmq.functional;
 
 import static org.junit.Assert.fail;
+
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.test.BrokerTestCase;
 import java.io.IOException;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/DirectReplyTo.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/DirectReplyTo.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.Connection;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/DurableOnTransient.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/DurableOnTransient.java
@@ -16,6 +16,7 @@
 package io.streamnative.pulsar.handlers.amqp.rabbitmq.functional;
 
 import static org.junit.Assert.assertNotNull;
+
 import com.rabbitmq.client.GetResponse;
 import com.rabbitmq.client.MessageProperties;
 import java.io.IOException;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/ExceptionHandling.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/ExceptionHandling.java
@@ -18,6 +18,7 @@ package io.streamnative.pulsar.handlers.amqp.rabbitmq.functional;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
+
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.Connection;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/ExceptionMessages.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/ExceptionMessages.java
@@ -18,6 +18,7 @@ package io.streamnative.pulsar.handlers.amqp.rabbitmq.functional;
 
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
 import com.rabbitmq.client.AlreadyClosedException;
 import com.rabbitmq.client.test.BrokerTestCase;
 import java.io.IOException;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/ExchangeDeclare.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/ExchangeDeclare.java
@@ -17,6 +17,7 @@
 package io.streamnative.pulsar.handlers.amqp.rabbitmq.functional;
 
 import static org.junit.Assert.assertEquals;
+
 import com.rabbitmq.client.BuiltinExchangeType;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.Connection;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/ExchangeDeleteIfUnused.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/ExchangeDeleteIfUnused.java
@@ -17,6 +17,7 @@
 package io.streamnative.pulsar.handlers.amqp.rabbitmq.functional;
 
 import static org.junit.Assert.fail;
+
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.test.BrokerTestCase;
 import java.io.IOException;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/ExchangeDeletePredeclared.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/ExchangeDeletePredeclared.java
@@ -17,6 +17,7 @@
 package io.streamnative.pulsar.handlers.amqp.rabbitmq.functional;
 
 import static org.junit.Assert.fail;
+
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.test.BrokerTestCase;
 import java.io.IOException;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/ExchangeEquivalenceBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/ExchangeEquivalenceBase.java
@@ -16,6 +16,7 @@
 package io.streamnative.pulsar.handlers.amqp.rabbitmq.functional;
 
 import static org.junit.Assert.fail;
+
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.test.BrokerTestCase;
 import java.io.IOException;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/ExchangeExchangeBindings.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/ExchangeExchangeBindings.java
@@ -19,6 +19,7 @@ package io.streamnative.pulsar.handlers.amqp.rabbitmq.functional;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+
 import com.rabbitmq.client.ShutdownSignalException;
 import com.rabbitmq.client.test.BrokerTestCase;
 import com.rabbitmq.client.test.QueueingConsumer;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/ExchangeExchangeBindingsAutoDelete.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/ExchangeExchangeBindingsAutoDelete.java
@@ -18,6 +18,7 @@
 package io.streamnative.pulsar.handlers.amqp.rabbitmq.functional;
 
 import static org.junit.Assert.fail;
+
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.test.BrokerTestCase;
 import java.io.IOException;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/FrameMax.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/FrameMax.java
@@ -19,6 +19,7 @@ package io.streamnative.pulsar.handlers.amqp.rabbitmq.functional;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.Address;
 import com.rabbitmq.client.Connection;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/HeadersExchangeValidation.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/HeadersExchangeValidation.java
@@ -16,6 +16,7 @@
 package io.streamnative.pulsar.handlers.amqp.rabbitmq.functional;
 
 import static org.junit.Assert.fail;
+
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.test.BrokerTestCase;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/Heartbeat.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/Heartbeat.java
@@ -18,6 +18,7 @@ package io.streamnative.pulsar.handlers.amqp.rabbitmq.functional;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+
 import com.rabbitmq.client.ConnectionFactory;
 import com.rabbitmq.client.impl.recovery.AutorecoveringConnection;
 import com.rabbitmq.client.test.BrokerTestCase;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/InternalExchange.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/InternalExchange.java
@@ -18,6 +18,7 @@
 package io.streamnative.pulsar.handlers.amqp.rabbitmq.functional;
 
 import static org.junit.Assert.assertTrue;
+
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.GetResponse;
 import com.rabbitmq.client.test.BrokerTestCase;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/MessageCount.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/MessageCount.java
@@ -15,6 +15,7 @@
 package io.streamnative.pulsar.handlers.amqp.rabbitmq.functional;
 
 import static org.junit.Assert.assertEquals;
+
 import com.rabbitmq.client.test.BrokerTestCase;
 import java.io.IOException;
 /**

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/Metrics.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/Metrics.java
@@ -18,6 +18,7 @@ package io.streamnative.pulsar.handlers.amqp.rabbitmq.functional;
 
 import static com.rabbitmq.client.test.TestUtils.waitAtMost;
 import static org.assertj.core.api.Assertions.assertThat;
+
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.Connection;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/Nack.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/Nack.java
@@ -18,6 +18,7 @@ package io.streamnative.pulsar.handlers.amqp.rabbitmq.functional;
 
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.test.QueueingConsumer;
 import java.util.HashSet;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/NoRequeueOnCancel.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/NoRequeueOnCancel.java
@@ -20,6 +20,7 @@ package io.streamnative.pulsar.handlers.amqp.rabbitmq.functional;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.Consumer;
 import com.rabbitmq.client.DefaultConsumer;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/PerConsumerPrefetch.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/PerConsumerPrefetch.java
@@ -16,6 +16,7 @@
 package io.streamnative.pulsar.handlers.amqp.rabbitmq.functional;
 
 import static io.streamnative.pulsar.handlers.amqp.rabbitmq.functional.TestQos.drain;
+
 import com.rabbitmq.client.GetResponse;
 import com.rabbitmq.client.test.BrokerTestCase;
 import com.rabbitmq.client.test.QueueingConsumer;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/PerMessageTTL.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/PerMessageTTL.java
@@ -19,6 +19,7 @@ package io.streamnative.pulsar.handlers.amqp.rabbitmq.functional;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.MessageProperties;
 import com.rabbitmq.client.test.QueueingConsumer;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/PerQueueTTL.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/PerQueueTTL.java
@@ -17,6 +17,7 @@
 package io.streamnative.pulsar.handlers.amqp.rabbitmq.functional;
 
 import static org.junit.Assert.fail;
+
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.MessageProperties;
 import java.io.IOException;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/PerQueueVsPerMessageTTL.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/PerQueueVsPerMessageTTL.java
@@ -16,6 +16,7 @@
 package io.streamnative.pulsar.handlers.amqp.rabbitmq.functional;
 
 import static org.junit.Assert.assertNull;
+
 import com.rabbitmq.client.AMQP;
 import java.io.IOException;
 import java.util.Collections;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/QueueExclusivity.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/QueueExclusivity.java
@@ -15,6 +15,7 @@
 package io.streamnative.pulsar.handlers.amqp.rabbitmq.functional;
 
 import static org.junit.Assert.fail;
+
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.Connection;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/QueueLease.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/QueueLease.java
@@ -17,6 +17,7 @@
 package io.streamnative.pulsar.handlers.amqp.rabbitmq.functional;
 
 import static org.junit.Assert.fail;
+
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.Consumer;
 import com.rabbitmq.client.DefaultConsumer;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/QueueLifecycle.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/QueueLifecycle.java
@@ -18,6 +18,7 @@
 package io.streamnative.pulsar.handlers.amqp.rabbitmq.functional;
 
 import static org.junit.Assert.fail;
+
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.Consumer;
 import com.rabbitmq.client.DefaultConsumer;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/QueueSizeLimit.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/QueueSizeLimit.java
@@ -20,6 +20,7 @@ package io.streamnative.pulsar.handlers.amqp.rabbitmq.functional;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+
 import com.rabbitmq.client.GetResponse;
 import com.rabbitmq.client.test.BrokerTestCase;
 import java.io.IOException;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/Recover.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/Recover.java
@@ -16,10 +16,12 @@
  */
 
 package io.streamnative.pulsar.handlers.amqp.rabbitmq.functional;
+
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.Consumer;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/Reject.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/Reject.java
@@ -18,6 +18,7 @@
 package io.streamnative.pulsar.handlers.amqp.rabbitmq.functional;
 
 import static org.junit.Assert.assertNull;
+
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.test.QueueingConsumer;
 import java.io.IOException;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/RequeueOnClose.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/RequeueOnClose.java
@@ -18,6 +18,7 @@ package io.streamnative.pulsar.handlers.amqp.rabbitmq.functional;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.DefaultConsumer;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/Routing.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/Routing.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
+
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.AlreadyClosedException;
 import com.rabbitmq.client.GetResponse;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/SaslMechanisms.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/SaslMechanisms.java
@@ -16,6 +16,7 @@
 package io.streamnative.pulsar.handlers.amqp.rabbitmq.functional;
 
 import static org.junit.Assert.fail;
+
 import com.rabbitmq.client.AuthenticationFailureException;
 import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.ConnectionFactory;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/TTLHandling.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/TTLHandling.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
+
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.GetResponse;
 import com.rabbitmq.client.test.BrokerTestCase;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/Tables.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/Tables.java
@@ -16,6 +16,7 @@ package io.streamnative.pulsar.handlers.amqp.rabbitmq.functional;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.AMQP.BasicProperties;
 import com.rabbitmq.client.impl.LongStringHelper;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/TestQos.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/TestQos.java
@@ -13,10 +13,12 @@
  */
 
 package io.streamnative.pulsar.handlers.amqp.rabbitmq.functional;
+
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
+
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.BuiltinExchangeType;
 import com.rabbitmq.client.Channel;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/TopologyRecoveryFiltering.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/TopologyRecoveryFiltering.java
@@ -23,6 +23,7 @@ import static com.rabbitmq.client.test.TestUtils.sendAndConsumeMessage;
 import static com.rabbitmq.client.test.TestUtils.waitAtMost;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.Connection;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/TopologyRecoveryRetry.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/TopologyRecoveryRetry.java
@@ -19,6 +19,7 @@ package io.streamnative.pulsar.handlers.amqp.rabbitmq.functional;
 import static com.rabbitmq.client.impl.recovery.TopologyRecoveryRetryLogic.RETRY_ON_QUEUE_NOT_FOUND_RETRY_HANDLER;
 import static com.rabbitmq.client.test.TestUtils.closeAllConnectionsAndWaitForRecovery;
 import static org.junit.Assert.assertTrue;
+
 import com.rabbitmq.client.ConnectionFactory;
 import com.rabbitmq.client.DefaultConsumer;
 import com.rabbitmq.client.test.BrokerTestCase;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/Transactions.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/Transactions.java
@@ -17,6 +17,7 @@ package io.streamnative.pulsar.handlers.amqp.rabbitmq.functional;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
+
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.GetResponse;
 import com.rabbitmq.client.test.BrokerTestCase;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/UnbindAutoDeleteExchange.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/UnbindAutoDeleteExchange.java
@@ -15,6 +15,7 @@
 package io.streamnative.pulsar.handlers.amqp.rabbitmq.functional;
 
 import static org.junit.Assert.fail;
+
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.test.BrokerTestCase;
 import java.io.IOException;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/UserIDHeader.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/UserIDHeader.java
@@ -15,6 +15,7 @@
 package io.streamnative.pulsar.handlers.amqp.rabbitmq.functional;
 
 import static org.junit.Assert.fail;
+
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.AlreadyClosedException;
 import com.rabbitmq.client.Channel;


### PR DESCRIPTION
### Motivation

The dependabots update of the checkstyle version ( #110 ) failed due to changes in the way the config file needs to be structured.  This PR updates the checkstyle version, AND fixes the config file.

### Modifications

This commit updates the checkstyle version, the checkstyle maven plugin
version.

This also updates the checkstyle config file to account for changes to
checkstyle configuration since the old version.

This also updates the files that were in "violation" of the checkstyle rules.

### Verifying this change

- [X] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API:  no
  - The schema: no
  - The default values of configurations: no
  - The wire protocol: no
  - The rest endpoints: no
  - The admin cli options: no
  - Anything that affects deployment: no

### Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
  - If a feature is not applicable for documentation, explain why? **It's a code quality dependency update**
  - If a feature is not documented yet in this PR, please create a followup issue for adding the documentation.  **not applicable**
