### PR TITLE
Improve AoP ProxyConfiguration

### DIFF
--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpProtocolHandler.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpProtocolHandler.java
@@ -25,6 +25,7 @@ import java.net.InetSocketAddress;
 import java.util.Map;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.ServiceConfigurationUtils;
 import org.apache.pulsar.broker.protocol.ProtocolHandler;
@@ -90,7 +91,7 @@ public class AmqpProtocolHandler implements ProtocolHandler {
         if (amqpConfig.isAmqpProxyEnable()) {
             ProxyConfiguration proxyConfig = new ProxyConfiguration();
             proxyConfig.setAmqpProxyPort(amqpConfig.getAmqpProxyPort());
-            proxyConfig.setAdvertisedAddress(amqpConfig.getAdvertisedAddress());
+            proxyConfig.setAdvertisedAddress(PulsarService.advertisedAddress(amqpConfig));
             proxyConfig.setBrokerServicePort(amqpConfig.getBrokerServicePort());
             ProxyService proxyService = new ProxyService(proxyConfig, service.getPulsar());
             try {

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpProtocolHandler.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpProtocolHandler.java
@@ -90,8 +90,11 @@ public class AmqpProtocolHandler implements ProtocolHandler {
         amqpBrokerService = new AmqpBrokerService(service.getPulsar());
         if (amqpConfig.isAmqpProxyEnable()) {
             ProxyConfiguration proxyConfig = new ProxyConfiguration();
-            proxyConfig.setAmqpProxyPort(amqpConfig.getAmqpProxyPort());
             proxyConfig.setAmqpTenant(amqpConfig.getAmqpTenant());
+            proxyConfig.setAmqpMaxNoOfChannels(amqpConfig.getAmqpMaxNoOfChannels());
+            proxyConfig.setAmqpMaxFrameSize(amqpConfig.getAmqpMaxFrameSize());
+            proxyConfig.setAmqpHeartBeat(amqpConfig.getAmqpHeartBeat());
+            proxyConfig.setAmqpProxyPort(amqpConfig.getAmqpProxyPort());
             proxyConfig.setBrokerServiceURL("pulsar://" + PulsarService.advertisedAddress(amqpConfig) + ":"
                     + amqpConfig.getBrokerServicePort().get());
             ProxyService proxyService = new ProxyService(proxyConfig, service.getPulsar());

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpProtocolHandler.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpProtocolHandler.java
@@ -91,8 +91,9 @@ public class AmqpProtocolHandler implements ProtocolHandler {
         if (amqpConfig.isAmqpProxyEnable()) {
             ProxyConfiguration proxyConfig = new ProxyConfiguration();
             proxyConfig.setAmqpProxyPort(amqpConfig.getAmqpProxyPort());
-            proxyConfig.setAdvertisedAddress(PulsarService.advertisedAddress(amqpConfig));
-            proxyConfig.setBrokerServicePort(amqpConfig.getBrokerServicePort());
+            proxyConfig.setAmqpTenant(amqpConfig.getAmqpTenant());
+            proxyConfig.setBrokerServiceURL("pulsar://" + PulsarService.advertisedAddress(amqpConfig) + ":"
+                    + amqpConfig.getBrokerServicePort().get());
             ProxyService proxyService = new ProxyService(proxyConfig, service.getPulsar());
             try {
                 proxyService.start();

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/proxy/ProxyConfiguration.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/proxy/ProxyConfiguration.java
@@ -13,11 +13,43 @@
  */
 package io.streamnative.pulsar.handlers.amqp.proxy;
 
-import io.streamnative.pulsar.handlers.amqp.AmqpServiceConfiguration;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.pulsar.common.configuration.Category;
+import org.apache.pulsar.common.configuration.FieldContext;
 
 /**
  * Configuration for AMQP proxy service.
  */
-public class ProxyConfiguration extends AmqpServiceConfiguration {
+@Getter
+@Setter
+public class ProxyConfiguration {
+
+    @Category
+    private static final String CATEGORY_AMQP = "AMQP on Pulsar";
+    @Category
+    private static final String CATEGORY_AMQP_PROXY = "AMQP Proxy";
+    @Category
+    private static final String CATEGORY_BROKER_DISCOVERY = "Broker Discovery";
+
+    @FieldContext(
+            category = CATEGORY_AMQP,
+            required = true,
+            doc = "Amqp on Pulsar Broker tenant"
+    )
+    private String amqpTenant = "public";
+
+    @FieldContext(
+            category = CATEGORY_AMQP_PROXY,
+            required = false,
+            doc = "The amqp proxy port"
+    )
+    private int amqpProxyPort = 5682;
+
+    @FieldContext(
+            category = CATEGORY_BROKER_DISCOVERY,
+            doc = "The service url points to the broker cluster"
+    )
+    private String brokerServiceURL;
 
 }

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/proxy/ProxyConfiguration.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/proxy/ProxyConfiguration.java
@@ -40,6 +40,27 @@ public class ProxyConfiguration {
     private String amqpTenant = "public";
 
     @FieldContext(
+            category = CATEGORY_AMQP,
+            required = true,
+            doc = "The maximum number of channels which can exist concurrently on a connection."
+    )
+    private int amqpMaxNoOfChannels = 64;
+
+    @FieldContext(
+            category = CATEGORY_AMQP,
+            required = true,
+            doc = "The maximum frame size on a connection."
+    )
+    private int amqpMaxFrameSize = 4 * 1024 * 1024;
+
+    @FieldContext(
+            category = CATEGORY_AMQP,
+            required = true,
+            doc = "The default heartbeat timeout on broker"
+    )
+    private int amqpHeartBeat = 60 * 1000;
+
+    @FieldContext(
             category = CATEGORY_AMQP_PROXY,
             required = false,
             doc = "The amqp proxy port"

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/proxy/ProxyService.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/proxy/ProxyService.java
@@ -81,8 +81,8 @@ public class ProxyService implements Closeable {
     private void configValid(ProxyConfiguration proxyConfig) {
         checkNotNull(proxyConfig);
         checkArgument(proxyConfig.getAmqpProxyPort() > 0);
-        checkNotNull(proxyConfig.getAdvertisedAddress());
-        checkNotNull(proxyConfig.getBrokerServicePort());
+        checkNotNull(proxyConfig.getAmqpTenant());
+        checkNotNull(proxyConfig.getBrokerServiceURL());
     }
 
     public void start() throws Exception {
@@ -97,9 +97,9 @@ public class ProxyService implements Closeable {
             throw new IOException("Failed to bind Pulsar Proxy on port " + proxyConfig.getAmqpProxyPort(), e);
         }
 
-        String brokerServiceUrl = "pulsar://" + proxyConfig.getAdvertisedAddress() + ":"
-                + proxyConfig.getBrokerServicePort().get();
-        this.pulsarClient = (PulsarClientImpl) PulsarClient.builder().serviceUrl(brokerServiceUrl).build();
+        this.pulsarClient = (PulsarClientImpl) PulsarClient.builder()
+                .serviceUrl(proxyConfig.getBrokerServiceURL())
+                .build();
 
         this.lookupHandler = new PulsarServiceLookupHandler(pulsarService, pulsarClient);
     }

--- a/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/AmqpConfigNameTest.java
+++ b/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/AmqpConfigNameTest.java
@@ -14,7 +14,6 @@
 package io.streamnative.pulsar.handlers.amqp.test;
 
 import io.streamnative.pulsar.handlers.amqp.AmqpServiceConfiguration;
-import io.streamnative.pulsar.handlers.amqp.proxy.ProxyConfiguration;
 import java.lang.reflect.Field;
 import lombok.extern.slf4j.Slf4j;
 import org.testng.Assert;
@@ -37,9 +36,6 @@ public class AmqpConfigNameTest {
 
         Class<AmqpServiceConfiguration> amqpServiceConfigurationClass = AmqpServiceConfiguration.class;
         checkConfigName(amqpServiceConfigurationClass);
-
-        Class<ProxyConfiguration> proxyConfigurationClass = ProxyConfiguration.class;
-        checkConfigName(proxyConfigurationClass);
     }
 
     private void checkConfigName(Class clazz) {
@@ -52,7 +48,6 @@ public class AmqpConfigNameTest {
                     valid, "The config name `" + field.getName() + "` should start with `"
                             + CATEGORY_NAME_PRE + "` or `" + FIELD_NAME_PRE + "`");
         }
-
     }
 
 }


### PR DESCRIPTION
### Motivation

Currently, the AoP proxy use `advertisedAddress` in config file `broker.conf` directly, this is not unreasonable.

### Modifications

Make the AoP `ProxyConfiguration` independent of `AmqpServiceConfiguration`, add the config `brokerServiceURL` used to connect with Pulsar Broker.

### Verifying this change

This change is already covered by existing tests.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (yes)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (yes)

### Documentation

  - Does this pull request introduce a new feature? (no)
