### PR TITLE
Bump pulsar to 2.7.0.8-rc-202102191415

### DIFF
--- a/amqp-impl/pom.xml
+++ b/amqp-impl/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.streamnative.pulsar.handlers</groupId>
     <artifactId>pulsar-protocol-handler-amqp-parent</artifactId>
-    <version>2.7.0.7</version>
+    <version>2.7.0.8-rc-202102191415</version>
   </parent>
 
   <groupId>io.streamnative.pulsar.handlers</groupId>

--- a/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/mock/MockSubscription.java
+++ b/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/mock/MockSubscription.java
@@ -123,8 +123,13 @@ public class MockSubscription implements Subscription {
         return null;
     }
 
-    @Override public void expireMessages(int messageTTLInSeconds) {
+    @Override public boolean expireMessages(int messageTTLInSeconds) {
+        return false;
+    }
 
+    @Override
+    public boolean expireMessages(Position position) {
+        return false;
     }
 
     @Override public void redeliverUnacknowledgedMessages(Consumer consumer) {

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
   <groupId>io.streamnative.pulsar.handlers</groupId>
   <artifactId>pulsar-protocol-handler-amqp-parent</artifactId>
-  <version>2.7.0.7</version>
+  <version>2.7.0.8-rc-202102191415</version>
   <name>StreamNative :: Pulsar Protocol Handler :: AoP Parent</name>
   <description>Parent for AMQP on Pulsar implemented using Pulsar Protocol Handler.</description>
 
@@ -46,7 +46,7 @@
     <log4j2.version>2.13.3</log4j2.version>
     <lombok.version>1.18.4</lombok.version>
     <mockito.version>2.22.0</mockito.version>
-    <pulsar.version>2.7.0.7</pulsar.version>
+    <pulsar.version>2.7.0.8-rc-202102191415</pulsar.version>
     <slf4j.version>1.7.25</slf4j.version>
     <spotbugs-annotations.version>3.1.8</spotbugs-annotations.version>
     <testcontainers.version>1.12.5</testcontainers.version>

--- a/tests-qpid-jms-client/pom.xml
+++ b/tests-qpid-jms-client/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.streamnative.pulsar.handlers</groupId>
     <artifactId>pulsar-protocol-handler-amqp-parent</artifactId>
-    <version>2.7.0.7</version>
+    <version>2.7.0.8-rc-202102191415</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.streamnative.pulsar.handlers</groupId>
     <artifactId>pulsar-protocol-handler-amqp-parent</artifactId>
-    <version>2.7.0.7</version>
+    <version>2.7.0.8-rc-202102191415</version>
   </parent>
 
   <groupId>io.streamnative.pulsar.handlers</groupId>


### PR DESCRIPTION
Besides bumping pulsar version, this PR also fixes the compile error caused by new `Subscription` interface.