### PR TITLE
Apply new getAppliedAdvertisedAddress signature

### DIFF
--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpProtocolHandler.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpProtocolHandler.java
@@ -95,7 +95,7 @@ public class AmqpProtocolHandler implements ProtocolHandler {
             proxyConfig.setAmqpHeartBeat(amqpConfig.getAmqpHeartBeat());
             proxyConfig.setAmqpProxyPort(amqpConfig.getAmqpProxyPort());
             proxyConfig.setBrokerServiceURL("pulsar://"
-                    + ServiceConfigurationUtils.getAppliedAdvertisedAddress(amqpConfig, false) + ":"
+                    + ServiceConfigurationUtils.getAppliedAdvertisedAddress(amqpConfig, true) + ":"
                     + amqpConfig.getBrokerServicePort().get());
             ProxyService proxyService = new ProxyService(proxyConfig, service.getPulsar());
             try {

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpProtocolHandler.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpProtocolHandler.java
@@ -95,7 +95,7 @@ public class AmqpProtocolHandler implements ProtocolHandler {
             proxyConfig.setAmqpHeartBeat(amqpConfig.getAmqpHeartBeat());
             proxyConfig.setAmqpProxyPort(amqpConfig.getAmqpProxyPort());
             proxyConfig.setBrokerServiceURL("pulsar://"
-                    + ServiceConfigurationUtils.getAppliedAdvertisedAddress(amqpConfig) + ":"
+                    + ServiceConfigurationUtils.getAppliedAdvertisedAddress(amqpConfig, false) + ":"
                     + amqpConfig.getBrokerServicePort().get());
             ProxyService proxyService = new ProxyService(proxyConfig, service.getPulsar());
             try {

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <log4j2.version>2.13.3</log4j2.version>
     <lombok.version>1.18.4</lombok.version>
     <mockito.version>2.22.0</mockito.version>
-    <pulsar.version>2.8.0-rc-202106071430</pulsar.version>
+    <pulsar.version>2.8.0.4</pulsar.version>
     <slf4j.version>1.7.25</slf4j.version>
     <spotbugs-annotations.version>3.1.8</spotbugs-annotations.version>
     <testcontainers.version>1.12.5</testcontainers.version>


### PR DESCRIPTION
### Motivation

https://github.com/apache/pulsar/pull/10961 changed the method signature of `ServiceConfigurationUtils#getAppliedAdvertisedAddress`, which causes AoP build failure.

### Modifications

Upgrade the Pulsar dependency to 2.8.0.4 that contains https://github.com/apache/pulsar/pull/10961, then add the second parameter to `getAppliedAdvertisedAddress`.

It should be noted that since Pulsar 2.8.0.4 introduced the API incompatibility with 2.8.0, after this change, AoP >= 2.8.0.4 cannot be compatible with Pulsar < 2.8.0.4 including the stable version 2.8.0.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.