### PR TITLE
[Branch-2.7.2] Fix the consumer construct method

### DIFF
--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpConsumer.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpConsumer.java
@@ -77,7 +77,7 @@ public class AmqpConsumer extends Consumer {
         PulsarApi.KeySharedMeta keySharedMeta, AmqpChannel channel, String consumerTag, String queueName,
         boolean autoAck) throws BrokerServiceException {
         super(subscription, subType, topicName, consumerId, priorityLevel, consumerName, maxUnackedMessages,
-            cnx, appId, metadata, readCompacted, subscriptionInitialPosition, keySharedMeta);
+            cnx, appId, metadata, readCompacted, subscriptionInitialPosition, keySharedMeta, null);
         this.channel = channel;
         this.queueContainer = queueContainer;
         this.autoAck = autoAck;

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <log4j2.version>2.13.3</log4j2.version>
     <lombok.version>1.18.4</lombok.version>
     <mockito.version>2.22.0</mockito.version>
-    <pulsar.version>2.7.2.7</pulsar.version>
+    <pulsar.version>2.7.2.8</pulsar.version>
     <slf4j.version>1.7.25</slf4j.version>
     <spotbugs-annotations.version>3.1.8</spotbugs-annotations.version>
     <testcontainers.version>1.12.5</testcontainers.version>


### PR DESCRIPTION
1. bump Pulsar version to `2.7.2.8`.
2. fix consumer construct method.
