### PR TITLE
Refactor the structure of release scripts to facilitate CI management

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,4 +1,17 @@
-#!/usr/bin/env bash
+#!/bin/bash
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 set -ex
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -ex
+
+echo "Releasing aop"
+
+version=${1#v}
+if [[ "x$version" == "x" ]]; then
+  echo "You need give a version number of the aop"
+  exit 1
+fi
+
+# Create a direcotry to save assets
+ASSETS_DIR=release
+mkdir $ASSETS_DIR
+
+mvn clean install -DskipTests -Dmaven.wagon.http.retryHandler.count=3
+mv amqp-impl/target/pulsar-protocol-handler-amqp-*.nar  ./$ASSETS_DIR
+cp README.md ./$ASSETS_DIR/pulsar-protocol-handler-amqp-readme.md

--- a/scripts/get-version.sh
+++ b/scripts/get-version.sh
@@ -1,4 +1,17 @@
-#!/usr/bin/env bash
+#!/bin/bash
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 set -e
 

--- a/scripts/get-version.sh
+++ b/scripts/get-version.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -e
+
+VERSION=`mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec | sed 's/^\(.*\)-SNAPSHOT/\1/'`
+echo ${VERSION}


### PR DESCRIPTION
### Motivation

In order to facilitate the management of the release process, we need to strictly standardize the naming of scripts and the structure of related directories 

### Changes

We changed the structure of related scripts and directories.

### Documentation

Not needed