### PR TITLE
Fix queue recovery problem when there is no routers bindings

### DIFF
--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/QueueContainer.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/QueueContainer.java
@@ -102,6 +102,9 @@ public class QueueContainer {
                         } catch (JsonProcessingException e) {
                             log.error("Json decode error in queue recover from properties", e);
                             queueCompletableFuture.completeExceptionally(e);
+                        } catch (Exception e) {
+                            log.error("Failed to recover routers for queue.", e);
+                            queueCompletableFuture.completeExceptionally(e);
                         }
                         queueCompletableFuture.complete(amqpQueue);
                     }

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/impl/PersistentQueue.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/impl/PersistentQueue.java
@@ -111,12 +111,15 @@ public class PersistentQueue extends AbstractAmqpQueue {
     public void recoverRoutersFromQueueProperties(Map<String, String> properties,
                                                   ExchangeContainer exchangeContainer,
                                                   NamespaceName namespaceName) throws JsonProcessingException {
-        if (null == properties || properties.size() == 0) {
+        if (null == properties || properties.isEmpty() || !properties.containsKey(ROUTERS)) {
             return;
         }
         List<AmqpQueueProperties> amqpQueueProperties = jsonMapper.readValue(properties.get(ROUTERS),
                 new TypeReference<List<AmqpQueueProperties>>() {
                 });
+        if (amqpQueueProperties == null) {
+            return;
+        }
         amqpQueueProperties.stream().forEach((amqpQueueProperty) -> {
             // recover exchange
             String exchangeName = amqpQueueProperty.getExchangeName();

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/proxy/ProxyConnection.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/proxy/ProxyConnection.java
@@ -120,7 +120,6 @@ public class ProxyConnection extends ChannelInboundHandlerAdapter implements
 
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
-//        log.info("ProxyConnection [channelRead] - access msg: {}", ((ByteBuf) msg));
         switch (state) {
             case Init:
             case RedirectLookup:
@@ -153,7 +152,7 @@ public class ProxyConnection extends ChannelInboundHandlerAdapter implements
                 log.info("ProxyConnection [channelRead] - closed");
                 break;
             default:
-                log.info("ProxyConnection [channelRead] - invalid state");
+                log.error("ProxyConnection [channelRead] - invalid state");
                 break;
         }
     }

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/proxy/ProxyHandler.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/proxy/ProxyHandler.java
@@ -169,71 +169,97 @@ public class ProxyHandler {
 
         @Override
         public void receiveConnectionStart(short i, short i1, FieldTable fieldTable, byte[] bytes, byte[] bytes1) {
-            log.info("ProxyBackendHandler [receiveConnectionStart]");
+            if (log.isDebugEnabled()) {
+                log.debug("ProxyBackendHandler [receiveConnectionStart]");
+            }
         }
 
         @Override
         public void receiveConnectionSecure(byte[] bytes) {
-            log.info("ProxyBackendHandler [receiveConnectionSecure]");
+            if (log.isDebugEnabled()) {
+                log.debug("ProxyBackendHandler [receiveConnectionSecure]");
+            }
         }
 
         @Override
         public void receiveConnectionRedirect(AMQShortString amqShortString, AMQShortString amqShortString1) {
-            log.info("ProxyBackendHandler [receiveConnectionRedirect]");
+            if (log.isDebugEnabled()) {
+                log.debug("ProxyBackendHandler [receiveConnectionRedirect]");
+            }
         }
 
         @Override
         public void receiveConnectionTune(int i, long l, int i1) {
-            log.info("ProxyBackendHandler [receiveConnectionTune]");
+            if (log.isDebugEnabled()) {
+                log.debug("ProxyBackendHandler [receiveConnectionTune]");
+            }
         }
 
         @Override
         public void receiveConnectionOpenOk(AMQShortString amqShortString) {
-            log.info("ProxyBackendHandler [receiveConnectionOpenOk]");
+            if (log.isDebugEnabled()) {
+                log.debug("ProxyBackendHandler [receiveConnectionOpenOk]");
+            }
             proxyConnection.writeFrame(connectResponseBody.generateFrame(0));
             state = State.Connected;
         }
 
         @Override
         public ProtocolVersion getProtocolVersion() {
-            log.info("ProxyBackendHandler [getProtocolVersion]");
+            if (log.isDebugEnabled()) {
+                log.debug("ProxyBackendHandler [getProtocolVersion]");
+            }
             return null;
         }
 
         @Override
         public ClientChannelMethodProcessor getChannelMethodProcessor(int i) {
-            log.info("ProxyBackendHandler [getChannelMethodProcessor]");
+            if (log.isDebugEnabled()) {
+                log.debug("ProxyBackendHandler [getChannelMethodProcessor]");
+            }
             return null;
         }
 
         @Override
         public void receiveConnectionClose(int i, AMQShortString amqShortString, int i1, int i2) {
-            log.info("ProxyBackendHandler [receiveConnectionClose]");
+            if (log.isDebugEnabled()) {
+                log.debug("ProxyBackendHandler [receiveConnectionClose]");
+            }
         }
 
         @Override
         public void receiveConnectionCloseOk() {
-            log.info("ProxyBackendHandler [receiveConnectionCloseOk]");
+            if (log.isDebugEnabled()) {
+                log.debug("ProxyBackendHandler [receiveConnectionCloseOk]");
+            }
         }
 
         @Override
         public void receiveHeartbeat() {
-            log.info("ProxyBackendHandler [receiveHeartbeat]");
+            if (log.isDebugEnabled()) {
+                log.debug("ProxyBackendHandler [receiveHeartbeat]");
+            }
         }
 
         @Override
         public void receiveProtocolHeader(ProtocolInitiation protocolInitiation) {
-            log.info("ProxyBackendHandler [receiveProtocolHeader]");
+            if (log.isDebugEnabled()) {
+                log.debug("ProxyBackendHandler [receiveProtocolHeader]");
+            }
         }
 
         @Override
         public void setCurrentMethod(int i, int i1) {
-            log.info("ProxyBackendHandler [setCurrentMethod]");
+            if (log.isDebugEnabled()) {
+                log.debug("ProxyBackendHandler [setCurrentMethod]");
+            }
         }
 
         @Override
         public boolean ignoreAllButCloseOk() {
-            log.info("ProxyBackendHandler [ignoreAllButCloseOk]");
+            if (log.isDebugEnabled()) {
+                log.debug("ProxyBackendHandler [ignoreAllButCloseOk]");
+            }
             return false;
         }
     }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/AmqpProtocolHandlerTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/AmqpProtocolHandlerTestBase.java
@@ -120,6 +120,8 @@ public abstract class AmqpProtocolHandlerTestBase {
         amqpConfig.setAllowAutoTopicCreation(true);
         amqpConfig.setAllowAutoTopicCreationType("partitioned");
         amqpConfig.setBrokerDeleteInactiveTopicsEnabled(false);
+        amqpConfig.setBrokerEntryMetadataInterceptors(
+                Sets.newHashSet("org.apache.pulsar.common.intercept.AppendIndexMetadataInterceptor"));
 
         // set protocol related config
         URL testHandlerUrl = this.getClass().getClassLoader().getResource("test-protocol-handler.nar");


### PR DESCRIPTION
### Motivation

Currently, if there is no routers bindings information in the properties of the managed-ledger, the queue recovery will encounter errors.

### Modifications

Check the properties of the managed-ledger, if there is no routers bindings property, skip the queue recovery.

### Verifying this change

Add a configuration `brokerEntryMetadataInterceptors=org.apache.pulsar.common.intercept.AppendIndexMetadataInterceptor` for mock broker to verify this change.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)
