### PR TITLE
Solve the problem of insufficient off-heap memory allocation during consumption.

### DIFF
--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpConsumer.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpConsumer.java
@@ -119,12 +119,7 @@ public class AmqpConsumer extends Consumer {
                     // Entry was filtered out
                     continue;
                 }
-                IndexMessage indexMessage;
-                try {
-                    indexMessage = MessageConvertUtils.entryToIndexMessage(index);
-                } finally {
-                    index.getDataBuffer().release();
-                }
+                IndexMessage indexMessage = MessageConvertUtils.entryToIndexMessage(index);
                 if (indexMessage == null) {
                     continue;
                 }
@@ -149,8 +144,6 @@ public class AmqpConsumer extends Consumer {
                                             AMQShortString.createAMQShortString(consumerTag));
                                 } catch (UnsupportedEncodingException e) {
                                     log.error("sendMessages UnsupportedEncodingException", e);
-                                } finally {
-                                    msg.getDataBuffer().release();
                                 }
 
                                 if (autoAck) {

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpConsumer.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpConsumer.java
@@ -119,7 +119,12 @@ public class AmqpConsumer extends Consumer {
                     // Entry was filtered out
                     continue;
                 }
-                IndexMessage indexMessage = MessageConvertUtils.entryToIndexMessage(index);
+                IndexMessage indexMessage;
+                try {
+                    indexMessage = MessageConvertUtils.entryToIndexMessage(index);
+                } finally {
+                    index.getDataBuffer().release();
+                }
                 if (indexMessage == null) {
                     continue;
                 }
@@ -144,6 +149,8 @@ public class AmqpConsumer extends Consumer {
                                             AMQShortString.createAMQShortString(consumerTag));
                                 } catch (UnsupportedEncodingException e) {
                                     log.error("sendMessages UnsupportedEncodingException", e);
+                                } finally {
+                                    msg.getDataBuffer().release();
                                 }
 
                                 if (autoAck) {

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpConsumer.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpConsumer.java
@@ -153,10 +153,10 @@ public class AmqpConsumer extends Consumer {
                                 } else {
                                     messagesAck(index.getPosition());
                                 }
-                                indexMessage.recycle();
                             } finally {
                                 msg.release();
                                 index.release();
+                                indexMessage.recycle();
                             }
                         })).exceptionally(throwable -> {
                             log.error("Failed to get queue from queue container", throwable);

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpConsumer.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpConsumer.java
@@ -126,36 +126,40 @@ public class AmqpConsumer extends Consumer {
                 asyncGetQueue().thenApply(amqpQueue -> amqpQueue.readEntryAsync(
                         indexMessage.getExchangeName(), indexMessage.getLedgerId(), indexMessage.getEntryId())
                         .whenComplete((msg, ex) -> {
-                            if (ex == null) {
-                                long deliveryTag = channel.getNextDeliveryTag();
+                            try {
+                                if (ex == null) {
+                                    long deliveryTag = channel.getNextDeliveryTag();
 
-                                addUnAckMessages(indexMessage.getExchangeName(), (PositionImpl) index.getPosition(),
-                                        (PositionImpl) msg.getPosition());
-                                if (!autoAck) {
-                                    channel.getUnacknowledgedMessageMap().add(deliveryTag,
-                                            index.getPosition(), this, msg.getLength());
-                                }
+                                    addUnAckMessages(indexMessage.getExchangeName(), (PositionImpl) index.getPosition(),
+                                            (PositionImpl) msg.getPosition());
+                                    if (!autoAck) {
+                                        channel.getUnacknowledgedMessageMap().add(deliveryTag,
+                                                index.getPosition(), this, msg.getLength());
+                                    }
 
-                                try {
-                                    connection.getAmqpOutputConverter().writeDeliver(
-                                            MessageConvertUtils.entryToAmqpBody(msg),
-                                            channel.getChannelId(), getRedeliveryTracker().
-                                                    contains(index.getPosition()), deliveryTag,
-                                            AMQShortString.createAMQShortString(consumerTag));
-                                } catch (UnsupportedEncodingException e) {
-                                    log.error("sendMessages UnsupportedEncodingException", e);
-                                }
+                                    try {
+                                        connection.getAmqpOutputConverter().writeDeliver(
+                                                MessageConvertUtils.entryToAmqpBody(msg),
+                                                channel.getChannelId(), getRedeliveryTracker().
+                                                        contains(index.getPosition()), deliveryTag,
+                                                AMQShortString.createAMQShortString(consumerTag));
+                                    } catch (UnsupportedEncodingException e) {
+                                        log.error("sendMessages UnsupportedEncodingException", e);
+                                    }
 
-                                if (autoAck) {
+                                    if (autoAck) {
+                                        messagesAck(index.getPosition());
+                                    }
+                                } else {
                                     messagesAck(index.getPosition());
                                 }
-                            } else {
-                                messagesAck(index.getPosition());
+                            } finally {
+                                msg.release();
+                                index.release();
                             }
-                            msg.release();
-                            index.release();
                             indexMessage.recycle();
                         })).exceptionally(throwable -> {
+                            index.release();
                             log.error("Failed to get queue from queue container", throwable);
                             return null;
                 });

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpConsumer.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpConsumer.java
@@ -153,13 +153,12 @@ public class AmqpConsumer extends Consumer {
                                 } else {
                                     messagesAck(index.getPosition());
                                 }
+                                indexMessage.recycle();
                             } finally {
                                 msg.release();
                                 index.release();
                             }
-                            indexMessage.recycle();
                         })).exceptionally(throwable -> {
-                            index.release();
                             log.error("Failed to get queue from queue container", throwable);
                             return null;
                 });

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/utils/MessageConvertUtils.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/utils/MessageConvertUtils.java
@@ -304,12 +304,11 @@ public final class MessageConvertUtils {
         //  then assemble deliver body with ContentHeaderBody and ContentBody
 
         ByteBuf metadataAndPayload = entry.getDataBuffer();
+        MessageMetadata msgMetadata = Commands.parseMessageMetadata(metadataAndPayload);
+        int numMessages = msgMetadata.getNumMessagesInBatch();
+        boolean notBatchMessage = (numMessages == 1 && !msgMetadata.hasNumMessagesInBatch());
+        ByteBuf payload = metadataAndPayload.retain();
         try {
-            MessageMetadata msgMetadata = Commands.parseMessageMetadata(metadataAndPayload);
-            int numMessages = msgMetadata.getNumMessagesInBatch();
-            boolean notBatchMessage = (numMessages == 1 && !msgMetadata.hasNumMessagesInBatch());
-            ByteBuf payload = metadataAndPayload.retain();
-
             if (log.isDebugEnabled()) {
                 log.debug("entryToRecord.  NumMessagesInBatch: {}, isBatchMessage: {}."
                         + " new entryId {}:{}, readerIndex: {},  writerIndex: {}",
@@ -339,7 +338,7 @@ public final class MessageConvertUtils {
             }
             return amqpMessage;
         } finally {
-            metadataAndPayload.release();
+            payload.release();
         }
     }
 

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/utils/MessageConvertUtils.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/utils/MessageConvertUtils.java
@@ -15,7 +15,6 @@ package io.streamnative.pulsar.handlers.amqp.utils;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
-
 import com.google.common.collect.ImmutableList;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -337,11 +336,10 @@ public final class MessageConvertUtils {
             } else {
                 // currently, no consider for batch
             }
+            return amqpMessage;
         } finally {
             metadataAndPayload.release();
         }
-
-        return amqpMessage;
     }
 
     private static String byteToString(byte b) throws UnsupportedEncodingException {

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/utils/MessageConvertUtils.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/utils/MessageConvertUtils.java
@@ -15,7 +15,6 @@ package io.streamnative.pulsar.handlers.amqp.utils;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
-
 import com.google.common.collect.ImmutableList;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -371,7 +370,8 @@ public final class MessageConvertUtils {
         try {
             long ledgerId = payload.readLong();
             long entryId = payload.readLong();
-            String exchangeName = payload.readCharSequence(payload.readableBytes(), StandardCharsets.ISO_8859_1).toString();
+            String exchangeName = payload.readCharSequence(payload.readableBytes(), StandardCharsets.ISO_8859_1)
+                    .toString();
             return IndexMessage.create(exchangeName, ledgerId, entryId);
         } finally {
             payload.release();

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/utils/MessageConvertUtils.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/utils/MessageConvertUtils.java
@@ -15,6 +15,7 @@ package io.streamnative.pulsar.handlers.amqp.utils;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+
 import com.google.common.collect.ImmutableList;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -364,16 +365,16 @@ public final class MessageConvertUtils {
     // Currently, one entry consist of one IndexMessage info
     public static IndexMessage entryToIndexMessage(Entry entry) {
         ByteBuf metadataAndPayload = entry.getDataBuffer();
-        try {
-            Commands.parseMessageMetadata(metadataAndPayload);
-            ByteBuf payload = metadataAndPayload.retain();
+        Commands.parseMessageMetadata(metadataAndPayload);
+        ByteBuf payload = metadataAndPayload.retain();
 
+        try {
             long ledgerId = payload.readLong();
             long entryId = payload.readLong();
             String exchangeName = payload.readCharSequence(payload.readableBytes(), StandardCharsets.ISO_8859_1).toString();
             return IndexMessage.create(exchangeName, ledgerId, entryId);
         } finally {
-            metadataAndPayload.release();
+            payload.release();
         }
     }
 

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/utils/MessageConvertUtils.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/utils/MessageConvertUtils.java
@@ -15,6 +15,7 @@ package io.streamnative.pulsar.handlers.amqp.utils;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+
 import com.google.common.collect.ImmutableList;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;


### PR DESCRIPTION
Reason: MessageConvertUtils.entryToIndexMessage and MessageConvertUtils.entryToAmqpBody called ByteBuf.retain(),
but did not call release.