### PR TITLE
Bump log4j2 version to `2.17.1`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     <grpc.version>1.18.0</grpc.version>
     <jackson.version>2.11.0</jackson.version>
     <jcommander.version>1.48</jcommander.version>
-    <log4j2.version>2.17.0</log4j2.version>
+    <log4j2.version>2.17.1</log4j2.version>
     <lombok.version>1.18.4</lombok.version>
     <mockito.version>2.22.0</mockito.version>
     <pulsar.version>2.9.0-rc-202110152205</pulsar.version>


### PR DESCRIPTION
Bump log4j2 version to `2.17.1` to address CVE-2021-44832.