### PR TITLE
Bump Pulsar to `2.10.0.0-rc-1`

### DIFF
--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpTopicManager.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpTopicManager.java
@@ -13,16 +13,16 @@
  */
 package io.streamnative.pulsar.handlers.amqp;
 
+import io.streamnative.pulsar.handlers.amqp.common.exception.EmptyLookupResultException;
+import io.streamnative.pulsar.handlers.amqp.common.exception.NamespaceNotFoundException;
 import java.lang.reflect.Field;
 import java.util.concurrent.CompletableFuture;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.bookkeeper.clients.exceptions.NamespaceNotFoundException;
 import org.apache.pulsar.broker.PulsarServerException;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.namespace.LookupOptions;
 import org.apache.pulsar.broker.service.AbstractTopic;
 import org.apache.pulsar.broker.service.Topic;
-import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.InactiveTopicDeleteMode;
 import org.apache.pulsar.common.policies.data.InactiveTopicPolicies;
@@ -53,12 +53,12 @@ public class AmqpTopicManager {
             topicCompletableFuture.completeExceptionally(new PulsarServerException("PulsarService is not set."));
             return topicCompletableFuture;
         }
-        TopicName tpName = TopicName.get(topicName);
+        final TopicName tpName = TopicName.get(topicName);
         // Check the namespace first to make sure the namespace is existing.
         pulsarService.getPulsarResources().getNamespaceResources().getPoliciesAsync(tpName.getNamespaceObject())
                 .thenCompose(policies -> {
                     if (!policies.isPresent()) {
-                        return FutureUtil.failedFuture(new NamespaceNotFoundException(tpName.getNamespace()));
+                        return FutureUtil.failedFuture(new NamespaceNotFoundException(tpName.getNamespaceObject()));
                     }
                     // setup ownership of service unit to this broker
                     return pulsarService.getNamespaceService().getBrokerServiceUrlAsync(
@@ -66,8 +66,7 @@ public class AmqpTopicManager {
                 })
                 .thenCompose(lookupOp -> {
                     if (!lookupOp.isPresent()) {
-                        return FutureUtil.failedFuture(new PulsarClientException.LookupException(
-                                "Lookup result is empty for " + topicName));
+                        return FutureUtil.failedFuture(new EmptyLookupResultException(tpName));
                     }
 
                     if (log.isDebugEnabled()) {

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/ExchangeContainer.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/ExchangeContainer.java
@@ -86,8 +86,7 @@ public class ExchangeContainer {
             CompletableFuture<Topic> topicCompletableFuture = amqpTopicManager.getTopic(topicName, createIfMissing);
             topicCompletableFuture.whenComplete((topic, throwable) -> {
                 if (throwable != null) {
-                    log.error("[{}][{}] Failed to get topic from amqpTopicManager.",
-                            namespaceName, exchangeName, throwable);
+                    log.error("[{}][{}] Failed to get exchange topic.", namespaceName, exchangeName, throwable);
                     amqpExchangeCompletableFuture.completeExceptionally(throwable);
                     removeExchangeFuture(namespaceName, exchangeName);
                 } else {

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/QueueContainer.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/QueueContainer.java
@@ -81,8 +81,7 @@ public class QueueContainer {
                     amqpTopicManager.getTopic(topicName, createIfMissing);
             topicCompletableFuture.whenComplete((topic, throwable) -> {
                 if (throwable != null) {
-                    log.error("[{}][{}] Failed to get topic from amqpTopicManager.",
-                            namespaceName, queueName, throwable);
+                    log.error("[{}][{}] Failed to get queue topic.", namespaceName, queueName, throwable);
                     queueCompletableFuture.completeExceptionally(throwable);
                     removeQueueFuture(namespaceName, queueName);
                 } else {

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/common/exception/EmptyLookupResultException.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/common/exception/EmptyLookupResultException.java
@@ -1,0 +1,24 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.amqp.common.exception;
+
+import org.apache.pulsar.common.naming.TopicName;
+
+public class EmptyLookupResultException extends Exception {
+
+    public EmptyLookupResultException(TopicName topicName) {
+        super("Lookup result is empty for " + topicName);
+    }
+
+}

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/common/exception/NamespaceNotFoundException.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/common/exception/NamespaceNotFoundException.java
@@ -1,0 +1,24 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.amqp.common.exception;
+
+import org.apache.pulsar.common.naming.NamespaceName;
+
+public class NamespaceNotFoundException extends Exception {
+
+    public NamespaceNotFoundException(NamespaceName namespaceName) {
+        super("Namespace " + namespaceName + " is not found.");
+    }
+
+}

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/common/exception/package-info.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/common/exception/package-info.java
@@ -1,0 +1,18 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Package info.
+ */
+package io.streamnative.pulsar.handlers.amqp.common.exception;

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/proxy/ProxyService.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/proxy/ProxyService.java
@@ -30,7 +30,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.common.util.netty.EventLoopUtil;
-import org.apache.pulsar.zookeeper.ZooKeeperClientFactory;
 
 /**
  * This service is used for redirecting AMQP client request to proper AMQP protocol handler Broker.
@@ -53,8 +52,6 @@ public class ProxyService implements Closeable {
     private DefaultThreadFactory acceptorThreadFactory = new DefaultThreadFactory("amqp-redirect-acceptor");
     private DefaultThreadFactory workerThreadFactory = new DefaultThreadFactory("amqp-redirect-io");
     private static final int numThreads = Runtime.getRuntime().availableProcessors();
-
-    private ZooKeeperClientFactory zkClientFactory = null;
 
     @Getter
     private static final Map<String, Pair<String, Integer>> vhostBrokerMap = Maps.newConcurrentMap();

--- a/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/AmqpProtocolTestBase.java
+++ b/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/AmqpProtocolTestBase.java
@@ -13,6 +13,7 @@
  */
 package io.streamnative.pulsar.handlers.amqp.test;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 
@@ -45,6 +46,8 @@ import org.apache.pulsar.broker.ServiceConfiguration;
 import org.apache.pulsar.broker.lookup.LookupResult;
 import org.apache.pulsar.broker.namespace.LookupOptions;
 import org.apache.pulsar.broker.namespace.NamespaceService;
+import org.apache.pulsar.broker.resources.NamespaceResources;
+import org.apache.pulsar.broker.resources.PulsarResources;
 import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.broker.service.Subscription;
 import org.apache.pulsar.broker.service.Topic;
@@ -55,6 +58,7 @@ import org.apache.pulsar.common.lookup.data.LookupData;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.HierarchyTopicPolicies;
+import org.apache.pulsar.common.policies.data.Policies;
 import org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap;
 import org.apache.qpid.server.protocol.ProtocolVersion;
 import org.apache.qpid.server.protocol.v0_8.AMQShortString;
@@ -147,6 +151,13 @@ public abstract class AmqpProtocolTestBase {
         Mockito.when(pulsarService.getOrderedExecutor()).thenReturn(
                 OrderedExecutor.newBuilder().numThreads(8).name("pulsar-ordered").build());
         Mockito.when(serviceConfiguration.getNumIOThreads()).thenReturn(2 * Runtime.getRuntime().availableProcessors());
+
+        NamespaceResources namespaceResources = Mockito.mock(NamespaceResources.class);
+        Mockito.when(namespaceResources.getPoliciesAsync(any()))
+                .thenReturn(CompletableFuture.completedFuture(Optional.of(new Policies())));
+        PulsarResources pulsarResources = Mockito.mock(PulsarResources.class);
+        Mockito.when(pulsarResources.getNamespaceResources()).thenReturn(namespaceResources);
+        Mockito.when(pulsarService.getPulsarResources()).thenReturn(pulsarResources);
     }
 
     private void mockBrokerService() {

--- a/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/AmqpProtocolTestBase.java
+++ b/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/AmqpProtocolTestBase.java
@@ -98,18 +98,18 @@ public abstract class AmqpProtocolTestBase {
     public void setup() throws Exception {
         mockPulsarService();
         mockBrokerService();
-        ConnectionContainer connectionContainer = Mockito.mock(ConnectionContainer.class);
+        ConnectionContainer connectionContainer = mock(ConnectionContainer.class);
         amqpBrokerService = new AmqpBrokerService(pulsarService, connectionContainer);
         amqpTopicManager = amqpBrokerService.getAmqpTopicManager();
 
         // 1.Init AMQP connection for connection methods and channel methods tests.
         connection = new MockConnection();
-        ChannelHandlerContext ctx = Mockito.mock(ChannelHandlerContext.class);
-        Channel channel = Mockito.mock(Channel.class);
-        SocketAddress socketAddress = Mockito.mock(SocketAddress.class);
+        ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+        Channel channel = mock(Channel.class);
+        SocketAddress socketAddress = mock(SocketAddress.class);
         Mockito.when(ctx.channel()).thenReturn(channel);
         Mockito.when(channel.remoteAddress()).thenReturn(socketAddress);
-        Mockito.when(ctx.pipeline()).thenReturn(Mockito.mock(ChannelPipeline.class));
+        Mockito.when(ctx.pipeline()).thenReturn(mock(ChannelPipeline.class));
         connection.channelActive(ctx);
         // 2.Init ByteBuffer sender for the test to send requests to AMQP server.
         toServerSender = new ToServerByteBufferSender(connection);
@@ -135,10 +135,10 @@ public abstract class AmqpProtocolTestBase {
     }
 
     private void mockPulsarService() throws PulsarServerException {
-        pulsarService = Mockito.mock(PulsarService.class);
-        PulsarAdmin adminClient = Mockito.mock(PulsarAdmin.class);
-        Namespaces namespaces = Mockito.mock(Namespaces.class);
-        ServiceConfiguration serviceConfiguration = Mockito.mock(ServiceConfiguration.class);
+        pulsarService = mock(PulsarService.class);
+        PulsarAdmin adminClient = mock(PulsarAdmin.class);
+        Namespaces namespaces = mock(Namespaces.class);
+        ServiceConfiguration serviceConfiguration = mock(ServiceConfiguration.class);
         Mockito.when(pulsarService.getAdminClient()).thenReturn(adminClient);
         Mockito.when(pulsarService.getAdminClient().namespaces()).thenReturn(namespaces);
         Mockito.when(pulsarService.getBrokerService()).then(new Answer<Object>() {
@@ -152,16 +152,16 @@ public abstract class AmqpProtocolTestBase {
                 OrderedExecutor.newBuilder().numThreads(8).name("pulsar-ordered").build());
         Mockito.when(serviceConfiguration.getNumIOThreads()).thenReturn(2 * Runtime.getRuntime().availableProcessors());
 
-        NamespaceResources namespaceResources = Mockito.mock(NamespaceResources.class);
+        NamespaceResources namespaceResources = mock(NamespaceResources.class);
         Mockito.when(namespaceResources.getPoliciesAsync(any()))
                 .thenReturn(CompletableFuture.completedFuture(Optional.of(new Policies())));
-        PulsarResources pulsarResources = Mockito.mock(PulsarResources.class);
+        PulsarResources pulsarResources = mock(PulsarResources.class);
         Mockito.when(pulsarResources.getNamespaceResources()).thenReturn(namespaceResources);
         Mockito.when(pulsarService.getPulsarResources()).thenReturn(pulsarResources);
     }
 
     private void mockBrokerService() {
-        brokerService = Mockito.mock(BrokerService.class);
+        brokerService = mock(BrokerService.class);
         Mockito.when(brokerService.executor()).thenReturn(mock(EventLoopGroup.class));
         Mockito.when(brokerService.pulsar()).thenReturn(pulsarService);
         Mockito.when(brokerService.getPulsar()).thenReturn(pulsarService);
@@ -177,15 +177,15 @@ public abstract class AmqpProtocolTestBase {
 
     private void initMockAmqpTopicManager(){
         CompletableFuture<Topic> completableFuture = new CompletableFuture<>();
-        PersistentTopic persistentTopic = Mockito.mock(PersistentTopic.class);
+        PersistentTopic persistentTopic = mock(PersistentTopic.class);
 
         CompletableFuture<Subscription> subFuture = new CompletableFuture<>();
-        Subscription subscription = Mockito.mock(Subscription.class);
+        Subscription subscription = mock(Subscription.class);
         Mockito.when(subscription.getTopic()).thenReturn(persistentTopic);
         subFuture.complete(subscription);
         Mockito.when(persistentTopic.createSubscription(Mockito.anyString(),
                 Mockito.any(), Mockito.anyBoolean())).thenReturn(subFuture);
-        Mockito.when(subscription.getDispatcher()).thenReturn(Mockito.mock(MockDispatcher.class));
+        Mockito.when(subscription.getDispatcher()).thenReturn(mock(MockDispatcher.class));
         Mockito.when(persistentTopic.getSubscriptions()).thenReturn(new ConcurrentOpenHashMap<>());
         Mockito.when(persistentTopic.getManagedLedger()).thenReturn(new MockManagedLedger());
         Mockito.when(persistentTopic.getBrokerService()).thenReturn(brokerService);
@@ -195,10 +195,10 @@ public abstract class AmqpProtocolTestBase {
         Mockito.when(persistentTopic.getHierarchyTopicPolicies()).thenReturn(spy(new HierarchyTopicPolicies()));
 
         completableFuture.complete(persistentTopic);
-        NamespaceService namespaceService = Mockito.mock(NamespaceService.class);
+        NamespaceService namespaceService = mock(NamespaceService.class);
 
         CompletableFuture<Optional<LookupResult>> lookupCompletableFuture = new CompletableFuture<>();
-        LookupResult lookupResult = Mockito.mock(LookupResult.class);
+        LookupResult lookupResult = mock(LookupResult.class);
         lookupCompletableFuture.complete(Optional.of(lookupResult));
         Mockito.when(connection.getPulsarService().getNamespaceService()).thenReturn(namespaceService);
         Mockito.when(namespaceService.getBrokerServiceUrlAsync(Mockito.any(TopicName.class),
@@ -208,7 +208,7 @@ public abstract class AmqpProtocolTestBase {
             return lookupCompletableFuture;
         });
 
-        LookupData lookupData = Mockito.mock(LookupData.class);
+        LookupData lookupData = mock(LookupData.class);
         Mockito.when(lookupResult.getLookupData()).thenReturn(lookupData);
         Mockito.when(lookupResult.getLookupData().getBrokerUrl()).thenReturn("127.0.0.1");
         CompletableFuture<Optional<Topic>> topicCompletableFuture = new CompletableFuture<>();
@@ -218,7 +218,7 @@ public abstract class AmqpProtocolTestBase {
         Mockito.when(brokerService.getTopic(Mockito.anyString(), Mockito.anyBoolean())).
                 thenReturn(topicCompletableFuture);
 
-        ManagedLedger managedLedger = Mockito.mock(ManagedLedgerImpl.class);
+        ManagedLedger managedLedger = mock(ManagedLedgerImpl.class);
         Mockito.when(persistentTopic.getManagedLedger()).thenReturn(managedLedger);
         Mockito.when(managedLedger.getCursors()).thenReturn(new ManagedCursorContainer());
     }
@@ -231,7 +231,7 @@ public abstract class AmqpProtocolTestBase {
         private MockChannel channelMethodProcessor;
 
         public MockConnection() throws PulsarServerException {
-            super(Mockito.mock(AmqpServiceConfiguration.class), amqpBrokerService);
+            super(mock(AmqpServiceConfiguration.class), amqpBrokerService);
             this.channelMethodProcessor = new MockChannel(0, this);
         }
 

--- a/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/AmqpProtocolTestBase.java
+++ b/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/AmqpProtocolTestBase.java
@@ -14,6 +14,7 @@
 package io.streamnative.pulsar.handlers.amqp.test;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
@@ -53,6 +54,7 @@ import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.common.lookup.data.LookupData;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.policies.data.HierarchyTopicPolicies;
 import org.apache.pulsar.common.util.collections.ConcurrentOpenHashMap;
 import org.apache.qpid.server.protocol.ProtocolVersion;
 import org.apache.qpid.server.protocol.v0_8.AMQShortString;
@@ -151,6 +153,7 @@ public abstract class AmqpProtocolTestBase {
         brokerService = Mockito.mock(BrokerService.class);
         Mockito.when(brokerService.executor()).thenReturn(mock(EventLoopGroup.class));
         Mockito.when(brokerService.pulsar()).thenReturn(pulsarService);
+        Mockito.when(brokerService.getPulsar()).thenReturn(pulsarService);
     }
 
     private void initDefaultExchange() {
@@ -167,6 +170,7 @@ public abstract class AmqpProtocolTestBase {
 
         CompletableFuture<Subscription> subFuture = new CompletableFuture<>();
         Subscription subscription = Mockito.mock(Subscription.class);
+        Mockito.when(subscription.getTopic()).thenReturn(persistentTopic);
         subFuture.complete(subscription);
         Mockito.when(persistentTopic.createSubscription(Mockito.anyString(),
                 Mockito.any(), Mockito.anyBoolean())).thenReturn(subFuture);
@@ -177,6 +181,7 @@ public abstract class AmqpProtocolTestBase {
         CompletableFuture deleteCpm = new CompletableFuture<>();
         Mockito.when(persistentTopic.delete()).thenReturn(deleteCpm);
         deleteCpm.complete(null);
+        Mockito.when(persistentTopic.getHierarchyTopicPolicies()).thenReturn(spy(new HierarchyTopicPolicies()));
 
         completableFuture.complete(persistentTopic);
         NamespaceService namespaceService = Mockito.mock(NamespaceService.class);

--- a/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/mock/MockManagedLedger.java
+++ b/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/mock/MockManagedLedger.java
@@ -349,4 +349,8 @@ public class MockManagedLedger implements ManagedLedger {
         return 0;
     }
 
+    @Override
+    public CompletableFuture<Long> getEarliestMessagePublishTimeInBacklog() {
+        return null;
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <log4j2.version>2.17.1</log4j2.version>
     <lombok.version>1.18.4</lombok.version>
     <mockito.version>2.22.0</mockito.version>
-    <pulsar.version>2.9.1.3</pulsar.version>
+    <pulsar.version>2.10.0.0-rc-1</pulsar.version>
     <slf4j.version>1.7.25</slf4j.version>
     <spotbugs-annotations.version>3.1.8</spotbugs-annotations.version>
     <testcontainers.version>1.12.5</testcontainers.version>
@@ -417,16 +417,6 @@
       <layout>default</layout>
       <url>https://repo1.maven.org/maven2</url>
     </repository>
-
-    <repository>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-      <id>bintray-yahoo-maven</id>
-      <name>bintray</name>
-      <url>https://yahoo.bintray.com/maven</url>
-    </repository>
-
   </repositories>
 
 </project>

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/AmqpProtocolHandlerTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/AmqpProtocolHandlerTestBase.java
@@ -19,17 +19,16 @@ import static org.mockito.Mockito.spy;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.MoreExecutors;
 import io.netty.channel.EventLoopGroup;
-import java.io.IOException;
 import java.lang.reflect.Field;
 import java.net.URI;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
@@ -52,12 +51,11 @@ import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.compaction.Compactor;
+import org.apache.pulsar.metadata.api.extended.MetadataStoreExtended;
 import org.apache.pulsar.metadata.impl.ZKMetadataStore;
-import org.apache.pulsar.zookeeper.ZooKeeperClientFactory;
-import org.apache.pulsar.zookeeper.ZookeeperClientFactoryImpl;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.MockZooKeeper;
-import org.apache.zookeeper.ZooKeeper;
+import org.apache.zookeeper.MockZooKeeperSession;
 import org.apache.zookeeper.data.ACL;
 
 /**
@@ -279,10 +277,11 @@ public abstract class AmqpProtocolHandlerTestBase {
 
     protected void setupBrokerMocks(PulsarService pulsar) throws Exception {
         // Override default providers with mocked ones
-        doReturn(mockZooKeeperClientFactory).when(pulsar).getZooKeeperClientFactory();
         doReturn(mockBookKeeperClientFactory).when(pulsar).newBookKeeperClientFactory();
-        doReturn(new ZKMetadataStore(mockZooKeeper)).when(pulsar).createLocalMetadataStore();
-        doReturn(new ZKMetadataStore(mockZooKeeper)).when(pulsar).createConfigurationMetadataStore();
+
+        MockZooKeeperSession mockZooKeeperSession = MockZooKeeperSession.newInstance(mockZooKeeper);
+        doReturn(new ZKMetadataStore(mockZooKeeperSession)).when(pulsar).createLocalMetadataStore();
+        doReturn(new ZKMetadataStore(mockZooKeeperSession)).when(pulsar).createConfigurationMetadataStore();
 
         Supplier<NamespaceService> namespaceServiceSupplier = () -> spy(new NamespaceService(pulsar));
         doReturn(namespaceServiceSupplier).when(pulsar).getNamespaceServiceProvider();
@@ -296,12 +295,10 @@ public abstract class AmqpProtocolHandlerTestBase {
         List<ACL> dummyAclList = new ArrayList<>(0);
 
         ZkUtils.createFullPathOptimistic(zk, "/ledgers/available/192.168.1.1:" + 5000,
-            "".getBytes(ZookeeperClientFactoryImpl.ENCODING_SCHEME), dummyAclList, CreateMode.PERSISTENT);
+                "".getBytes(StandardCharsets.UTF_8), dummyAclList, CreateMode.PERSISTENT);
 
-        zk.create(
-            "/ledgers/LAYOUT",
-            "1\nflat:1".getBytes(ZookeeperClientFactoryImpl.ENCODING_SCHEME), dummyAclList,
-            CreateMode.PERSISTENT);
+        zk.create("/ledgers/LAYOUT", "1\nflat:1".getBytes(StandardCharsets.UTF_8), dummyAclList,
+                CreateMode.PERSISTENT);
         return zk;
     }
 
@@ -333,31 +330,23 @@ public abstract class AmqpProtocolHandlerTestBase {
         }
     }
 
-    protected ZooKeeperClientFactory mockZooKeeperClientFactory = new ZooKeeperClientFactory() {
+    private final BookKeeperClientFactory mockBookKeeperClientFactory = new BookKeeperClientFactory() {
 
         @Override
-        public CompletableFuture<ZooKeeper> create(String serverList, SessionType sessionType,
-                                                   int zkSessionTimeoutMillis) {
-            // Always return the same instance
-            // (so that we don't loose the mock ZK content on broker restart
-            return CompletableFuture.completedFuture(mockZooKeeper);
-        }
-    };
-
-    private BookKeeperClientFactory mockBookKeeperClientFactory = new BookKeeperClientFactory() {
-
-        @Override
-        public BookKeeper create(ServiceConfiguration conf, ZooKeeper zkClient, EventLoopGroup eventLoopGroup,
+        public BookKeeper create(ServiceConfiguration conf, MetadataStoreExtended store,
+                                 EventLoopGroup eventLoopGroup,
                                  Optional<Class<? extends EnsemblePlacementPolicy>> ensemblePlacementPolicyClass,
-                                 Map<String, Object> ensemblePlacementPolicyProperties) throws IOException {
+                                 Map<String, Object> properties) {
+            // Always return the same instance (so that we don't loose the mock BK content on broker restart
             return mockBookKeeper;
         }
 
         @Override
-        public BookKeeper create(ServiceConfiguration conf, ZooKeeper zkClient, EventLoopGroup eventLoopGroup,
+        public BookKeeper create(ServiceConfiguration conf, MetadataStoreExtended store,
+                                 EventLoopGroup eventLoopGroup,
                                  Optional<Class<? extends EnsemblePlacementPolicy>> ensemblePlacementPolicyClass,
-                                 Map<String, Object> ensemblePlacementPolicyProperties, StatsLogger statsLogger)
-                throws IOException {
+                                 Map<String, Object> properties, StatsLogger statsLogger) {
+            // Always return the same instance (so that we don't loose the mock BK content on broker restart
             return mockBookKeeper;
         }
 
@@ -365,7 +354,6 @@ public abstract class AmqpProtocolHandlerTestBase {
         public void close() {
             // no-op
         }
-
     };
 
     public static void retryStrategically(Predicate<Void> predicate, int retryCount, long intSleepTimeInMillis)

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/RabbitMQMessagingTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/RabbitMQMessagingTest.java
@@ -64,7 +64,9 @@ public class RabbitMQMessagingTest extends AmqpTestBase {
         }
 
         admin.namespaces().createNamespace("public/" + newAddedVhost);
-        unknownConn.close();
+        if (unknownConn.isOpen()) {
+            unknownConn.close();
+        }
         basicConsume(newAddedVhost);
     }
 


### PR DESCRIPTION
### Motivation

Bump Pulsar to `2.10.0.0-rc-1` and adjust some logic.

###  Modification

A key point change is that, if the namespace isn't existing, the topic manager will return a fenced topic, I add a check for the fenced topic.
Add a namespace existing check before getting the topic.