### PR TITLE
Adjust AMQP consumer constructor

### DIFF
--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpChannel.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpChannel.java
@@ -269,7 +269,7 @@ public class AmqpChannel implements ServerChannelMethodProcessor {
                 consumer = new AmqpConsumer(queueContainer, subscription, exclusive
                         ? CommandSubscribe.SubType.Exclusive :
                         CommandSubscribe.SubType.Shared, topic.getName(), 0, 0,
-                        finalConsumerTag, 0, connection.getServerCnx(), "", null,
+                        finalConsumerTag, true, connection.getServerCnx(), "", null,
                         false, CommandSubscribe.InitialPosition.Latest,
                         null, this, finalConsumerTag, queueName, ack);
             } catch (BrokerServiceException e) {
@@ -386,7 +386,7 @@ public class AmqpChannel implements ServerChannelMethodProcessor {
                             }
                             consumer = new AmqpPullConsumer(queueContainer, subscription,
                                     CommandSubscribe.SubType.Shared,
-                                    topic.getName(), 0, 0, "", 0,
+                                    topic.getName(), 0, 0, "", true,
                                     connection.getServerCnx(), "", null, false,
                                     CommandSubscribe.InitialPosition.Latest, null, this,
                                     "", queueName, noAck);

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpConsumer.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpConsumer.java
@@ -73,12 +73,12 @@ public class AmqpConsumer extends Consumer {
 
     public AmqpConsumer(QueueContainer queueContainer, Subscription subscription,
         CommandSubscribe.SubType subType, String topicName, long consumerId,
-        int priorityLevel, String consumerName, int maxUnackedMessages, ServerCnx cnx,
+        int priorityLevel, String consumerName, boolean isDurable, ServerCnx cnx,
         String appId, Map<String, String> metadata, boolean readCompacted,
         CommandSubscribe.InitialPosition subscriptionInitialPosition,
         KeySharedMeta keySharedMeta, AmqpChannel channel, String consumerTag, String queueName,
         boolean autoAck) throws BrokerServiceException {
-        super(subscription, subType, topicName, consumerId, priorityLevel, consumerName, maxUnackedMessages,
+        super(subscription, subType, topicName, consumerId, priorityLevel, consumerName, isDurable,
             cnx, appId, metadata, readCompacted, subscriptionInitialPosition, keySharedMeta, null);
         this.channel = channel;
         this.queueContainer = queueContainer;

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpPullConsumer.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpPullConsumer.java
@@ -29,14 +29,13 @@ public class AmqpPullConsumer extends AmqpConsumer {
 
     public AmqpPullConsumer(QueueContainer queueContainer, Subscription subscription,
         CommandSubscribe.SubType subType, String topicName, long consumerId, int priorityLevel,
-        String consumerName, int maxUnackedMessages, ServerCnx cnx, String appId,
+        String consumerName, boolean isDurable, ServerCnx cnx, String appId,
         Map<String, String> metadata, boolean readCompacted,
         CommandSubscribe.InitialPosition subscriptionInitialPosition,
         KeySharedMeta keySharedMeta, AmqpChannel channel, String consumerTag, String queueName,
         boolean autoAck) throws BrokerServiceException {
         super(queueContainer, subscription, subType, topicName, consumerId, priorityLevel, consumerName,
-                maxUnackedMessages,
-            cnx, appId, metadata, readCompacted, subscriptionInitialPosition, keySharedMeta, channel,
+                isDurable, cnx, appId, metadata, readCompacted, subscriptionInitialPosition, keySharedMeta, channel,
             consumerTag, queueName, autoAck);
     }
 

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpTopicManager.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpTopicManager.java
@@ -91,6 +91,8 @@ public class AmqpTopicManager {
                         persistentTopic.getHierarchyTopicPolicies().getInactiveTopicPolicies()
                                 .updateTopicValue(new InactiveTopicPolicies(
                                         InactiveTopicDeleteMode.delete_when_no_subscriptions, 1000, false));
+                        persistentTopic.getHierarchyTopicPolicies().getMaxUnackedMessagesOnConsumer()
+                                .updateTopicValue(0);
                         topicCompletableFuture.complete(persistentTopic);
                     } catch (Exception e) {
                         log.error("Failed to get client in registerInPersistentTopic {}. ", topicName, e);

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <log4j2.version>2.17.1</log4j2.version>
     <lombok.version>1.18.4</lombok.version>
     <mockito.version>2.22.0</mockito.version>
-    <pulsar.version>2.10.0.0-rc-1</pulsar.version>
+    <pulsar.version>2.10.0.0-rc2</pulsar.version>
     <slf4j.version>1.7.25</slf4j.version>
     <spotbugs-annotations.version>3.1.8</spotbugs-annotations.version>
     <testcontainers.version>1.12.5</testcontainers.version>


### PR DESCRIPTION
### Modifications

1. Bump Pulsar to `2.10.0.0-rc2`.
2. Adjust AMQP consumer constructor for Pulsar `2.10.0.0-rc2` change.

Don't change the AoP behavior, the maxUnackedMessages is still 0.

### Verifying this change

This change is already covered by existing tests.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

