### PR TITLE
[Issues#470]bug fix: Message delivery lost.

### DIFF
--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpChannel.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpChannel.java
@@ -103,10 +103,10 @@ public class AmqpChannel implements ServerChannelMethodProcessor {
     /**
      * This tag is unique per subscription to a queue. The server returns this in response to a basic.consume request.
      */
-    private final AtomicLong CONSUMER_TAG = new AtomicLong(0);
+    private final AtomicLong consumerTag = new AtomicLong(0);
 
     /**
-     * The consumer ID
+     * The consumer ID.
      */
     private static final AtomicLong CONSUMER_ID = new AtomicLong(0);
 
@@ -751,7 +751,7 @@ public class AmqpChannel implements ServerChannelMethodProcessor {
     }
 
     private long getNextConsumerTag() {
-        return CONSUMER_TAG.incrementAndGet();
+        return consumerTag.incrementAndGet();
     }
 
     public AmqpConnection getConnection() {

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpChannel.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpChannel.java
@@ -227,7 +227,7 @@ public class AmqpChannel implements ServerChannelMethodProcessor {
         if (consumerTag == null) {
             consumerTag1 = "consumerTag_" + getNextConsumerTag() + "_" + channelId;
         } else {
-            consumerTag1 = consumerTag + "_" + channelId;
+            consumerTag1 = consumerTag.toString();
         }
         CompletableFuture<AmqpQueue> amqpQueueCompletableFuture =
                 queueContainer.asyncGetQueue(connection.getNamespaceName(), queue.toString(), false);
@@ -297,7 +297,7 @@ public class AmqpChannel implements ServerChannelMethodProcessor {
     @Override
     public void receiveBasicCancel(AMQShortString consumerTag, boolean noWait) {
         if (log.isDebugEnabled()) {
-            log.debug("RECV[ {} ] BasicCancel[ consumerTag: {}  noWait: {} ]", channelId, consumerTag, noWait);
+            log.debug("RECV[{}] BasicCancel[ consumerTag: {}  noWait: {} ]", channelId, consumerTag, noWait);
         }
 
         unsubscribeConsumer(AMQShortString.toString(consumerTag));

--- a/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/AmqpChannelMethodTest.java
+++ b/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/AmqpChannelMethodTest.java
@@ -405,8 +405,7 @@ public class AmqpChannelMethodTest extends AmqpProtocolTestBase {
     public void testBasicAckOne() {
         testBasicConsume();
         AmqpChannel channel = (AmqpChannel) connection.getChannelMethodProcessor(0);
-        AmqpConsumer consumer = (AmqpConsumer) channel.getTag2ConsumersMap()
-                .get("consumerTag1_" + channel.getChannelId());
+        AmqpConsumer consumer = (AmqpConsumer) channel.getTag2ConsumersMap().get("consumerTag1");
         Assert.assertTrue(consumer != null);
         UnacknowledgedMessageMap unacknowledgedMessageMap = channel.getUnacknowledgedMessageMap();
         unacknowledgedMessageMap.add(1, PositionImpl.get(1, 1), consumer, 0);
@@ -423,8 +422,7 @@ public class AmqpChannelMethodTest extends AmqpProtocolTestBase {
     public void testBasicAckBatch() {
         testBasicConsume();
         AmqpChannel channel = (AmqpChannel) connection.getChannelMethodProcessor(0);
-        AmqpConsumer consumer = (AmqpConsumer) channel.getTag2ConsumersMap()
-                .get("consumerTag1_" + channel.getChannelId());
+        AmqpConsumer consumer = (AmqpConsumer) channel.getTag2ConsumersMap().get("consumerTag1");
         Assert.assertTrue(consumer != null);
         UnacknowledgedMessageMap unacknowledgedMessageMap = channel.getUnacknowledgedMessageMap();
         unacknowledgedMessageMap.add(1, PositionImpl.get(1, 1), consumer, 0);

--- a/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/AmqpChannelMethodTest.java
+++ b/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/AmqpChannelMethodTest.java
@@ -405,7 +405,8 @@ public class AmqpChannelMethodTest extends AmqpProtocolTestBase {
     public void testBasicAckOne() {
         testBasicConsume();
         AmqpChannel channel = (AmqpChannel) connection.getChannelMethodProcessor(0);
-        AmqpConsumer consumer = (AmqpConsumer) channel.getTag2ConsumersMap().get("consumerTag1");
+        AmqpConsumer consumer = (AmqpConsumer) channel.getTag2ConsumersMap()
+                .get("consumerTag1_" + channel.getChannelId());
         Assert.assertTrue(consumer != null);
         UnacknowledgedMessageMap unacknowledgedMessageMap = channel.getUnacknowledgedMessageMap();
         unacknowledgedMessageMap.add(1, PositionImpl.get(1, 1), consumer, 0);
@@ -422,7 +423,8 @@ public class AmqpChannelMethodTest extends AmqpProtocolTestBase {
     public void testBasicAckBatch() {
         testBasicConsume();
         AmqpChannel channel = (AmqpChannel) connection.getChannelMethodProcessor(0);
-        AmqpConsumer consumer = (AmqpConsumer) channel.getTag2ConsumersMap().get("consumerTag1");
+        AmqpConsumer consumer = (AmqpConsumer) channel.getTag2ConsumersMap()
+                .get("consumerTag1_" + channel.getChannelId());
         Assert.assertTrue(consumer != null);
         UnacknowledgedMessageMap unacknowledgedMessageMap = channel.getUnacknowledgedMessageMap();
         unacknowledgedMessageMap.add(1, PositionImpl.get(1, 1), consumer, 0);

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/RabbitMQMessagingTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/RabbitMQMessagingTest.java
@@ -408,8 +408,10 @@ public class RabbitMQMessagingTest extends AmqpTestBase {
         CountDownLatch countDownLatch2 = new CountDownLatch(messageCnt * 2);
         AtomicInteger consumeIndex = new AtomicInteger(0);
 
-        Channel channel1 = createConsumer(exchangeName, routingKey, queueName, conn, countDownLatch1, countDownLatch2, consumeIndex);
-        Channel channel2 = createConsumer(exchangeName, routingKey, queueName, conn, countDownLatch1, countDownLatch2, consumeIndex);
+        Channel channel1 = createConsumer(exchangeName, routingKey, queueName, conn,
+                countDownLatch1, countDownLatch2, consumeIndex);
+        Channel channel2 = createConsumer(exchangeName, routingKey, queueName, conn,
+                countDownLatch1, countDownLatch2, consumeIndex);
 
         for (int i = 0; i < messageCnt; i++) {
             byte[] messageBodyBytes = ("Hello, world! - " + i).getBytes();
@@ -421,9 +423,10 @@ public class RabbitMQMessagingTest extends AmqpTestBase {
         channel1.close();
         channel2.close();
 
-        Channel channel3 = createConsumer(exchangeName, routingKey, queueName, conn, null, countDownLatch2, consumeIndex);
+        Channel channel3 = createConsumer(exchangeName, routingKey, queueName, conn,
+                null, countDownLatch2, consumeIndex);
 
-        for (int i = 0; i <= messageCnt * 2; i++) {
+        for (int i = 0; i <= messageCnt; i++) {
             byte[] messageBodyBytes = ("Hello, world! - " + i).getBytes();
             channel3.basicPublish(exchangeName, routingKey, null, messageBodyBytes);
         }


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[Issue XYZ][component] Title of the pull request", where *XYZ* should be replaced by the actual issue number.
    Skip *Issue XYZ* if there is no associated github issue for this pull request.
    Skip *component* if you are unsure about which is the best component. E.g. `[docs] Fix typo in produce method`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->


Fixes #470



### Motivation

pulsar-protocol-handler-amqp: 2.8.1.9
Client pom.xml use：com.alibaba.mq-amqp#mq-amqp-client#1.0.5
Client config：
```
spring.amqp.order.host = 
spring.amqp.order.port = 
spring.amqp.order.virtual-host = 
spring.amqp.template.order.mandatory = true
spring.amqp.order.publisher-confirms = true
spring.amqp.order.publisher-returns = true
#spring.amqp.listener.direct.acknowledge-mode = manual
spring.amqp.listener.simple.order.acknowledge-mode = manual
spring.amqp.listener.simple.order.concurrency = 2
spring.amqp.listener.simple.order.max-concurrency = 2
spring.amqp.listener.simple.order.prefetch = 200
spring.amqp.listener.order.auto-startup = true
```

spring bean config:
```
@Slf4j
@Component
public class AMQPConfig {

    private static final String ACKNOWLEDGE_AUTO = "auto";

    private static final String ACKNOWLEDGE_MANUAL = "manual";

    private static final String ACKNOWLEDGE_NONE = "none";

    private static final AtomicInteger count = new AtomicInteger(0);

    @Bean("amqpOrderAdmin")
    public AmqpAdmin amqpOrderAdmin(@Qualifier("amqpOrderConnectionFactory") ConnectionFactory connectionFactory) {
        return new RabbitAdmin(connectionFactory);
    }

    @Bean(name = "amqpOrderConnectionFactory")
    public ConnectionFactory amqpOrderConnectionFactory(
            @Value("${spring.amqp.order.host}") String host,
            @Value("${spring.amqp.order.port}") int port,
            @Value("${spring.amqp.order.virtual-host}") String virtualHost,
            @Value("${spring.amqp.order.publisher-confirms}") boolean publisherConfirms,
            @Value("${spring.amqp.order.publisher-returns}") boolean publisherReturns
    ) {
        CachingConnectionFactory connectionFactory = new CachingConnectionFactory();
        connectionFactory.setHost(host);
        connectionFactory.setPort(port);
        connectionFactory.setVirtualHost(virtualHost);
        connectionFactory.setPublisherConfirms(publisherConfirms);
        connectionFactory.setPublisherReturns(publisherReturns);
        return connectionFactory;
    }


    @Bean(name = "amqpOrderRabbitTemplate")
    public RabbitTemplate amqpOrderRabbitTemplate(
            @Qualifier("amqpOrderConnectionFactory") ConnectionFactory connectionFactory,
            @Value("${spring.amqp.template.order.mandatory}") boolean mandatory
    ) {
        RabbitTemplate amqpOrderRabbitTemplate = new RabbitTemplate(connectionFactory);
        amqpOrderRabbitTemplate.setMandatory(mandatory);

        amqpOrderRabbitTemplate.setConfirmCallback((correlationData, b, s) -> {
            int i = count.incrementAndGet();
            log.info("开启发送确认数量:{} correlationData：{} params2:{} params3:{}", i, correlationData, b, s);
        });

        return amqpOrderRabbitTemplate;
    }

    @Bean(name = "amqpOrderFactory")
    public SimpleRabbitListenerContainerFactory amqpOrderFactory(
            @Qualifier("amqpOrderConnectionFactory") ConnectionFactory connectionFactory,
            @Value("${spring.amqp.listener.simple.order.concurrency}") int concurrency,
            @Value("${spring.amqp.listener.simple.order.max-concurrency}") int maxConcurrency,
            @Value("${spring.amqp.listener.simple.order.prefetch}") int prefetch,
            @Value("${spring.amqp.listener.simple.order.acknowledge-mode}") String acknowledgeMode,
            @Value("${spring.amqp.listener.order.auto-startup:true}") boolean autoStartup
    ) {
        SimpleRabbitListenerContainerFactory factory = new SimpleRabbitListenerContainerFactory();
        factory.setPrefetchCount(prefetch);
        factory.setAcknowledgeMode(parseAcknowledge(acknowledgeMode));
        factory.setConcurrentConsumers(concurrency);
        factory.setMaxConcurrentConsumers(maxConcurrency);

        factory.setConnectionFactory(connectionFactory);
        factory.setAutoStartup(autoStartup);
        return factory;
    }


    private AcknowledgeMode parseAcknowledge(String acknowledge) {
        AcknowledgeMode acknowledgeMode;
        if (ACKNOWLEDGE_AUTO.equals(acknowledge)) {
            acknowledgeMode = AcknowledgeMode.AUTO;
        } else if (ACKNOWLEDGE_MANUAL.equals(acknowledge)) {
            acknowledgeMode = AcknowledgeMode.MANUAL;
        } else if (ACKNOWLEDGE_NONE.equals(acknowledge)) {
            acknowledgeMode = AcknowledgeMode.NONE;
        } else {
            throw new IllegalStateException("Unsupported acknowledge: " + acknowledge);
        }

        return acknowledgeMode;
    }

}
```



consumer and producer code:
```
@Slf4j
@Component
public class AMQP implements CommandLineRunner {

    @Resource(name = "amqpOrderRabbitTemplate")
    private RabbitTemplate template;

    private AtomicInteger count = new AtomicInteger(0);

    @RabbitHandler
    @RabbitListener(bindings = @QueueBinding(
            value = @Queue(value = "mytest.unpaid-reminder-order-create-queue",durable = "true"),
            exchange = @Exchange(name="mytest.order.topic", type = "topic"),
            key = "order.*"
    ),containerFactory = "amqpOrderFactory")
    public void amqp(Message message, Channel channel, @Headers Map<String, Object> heads) {
        log.info("数量:{} ChannelNumber:{} 收到消息:{} head:{}", count.incrementAndGet(), channel.getChannelNumber(), new String(message.getBody(), StandardCharsets.UTF_8), heads);
        try {
            channel.basicAck((Long) heads.get(AmqpHeaders.DELIVERY_TAG), false);
        } catch (IOException e) {
            e.printStackTrace();
        }
    }


    @Override
    public void run(String... args) throws Exception {
        for (int i = 1; i <= 10; i++) {
            template.convertAndSend("mytest.order.topic", "order.create", i + "", message -> message);
        }
    }
}
```



Current problem: the message is lost. If you send 10 messages, you can only receive 7 or 8 messages. Even if the client restarts, you can't receive other messages.


Question 1. 
Code entry {io.streamnative.pulsar.handlers.amqp.Amqpchannel#receivebasicconsume}

When requesting to create a consumer, the consumertag of different channels is the same, and the ID of amqpconsumer is 0, which will lead to {subscription.addconsumer(consumer)} has a serious problem. You can see that {consumerset.add(consumer)} is used in the code of {org.apache.pulsar.broker.service.persistent.persistentDispatcherMultipleConsumers #addconsumer};

Only one can be added successfully because hashcode and equals are overridden, but the consumerlist can add multiple successfully. When consumer is deleted, it is judged that {this.consumerset.removeAll(consumer) == 1}. The code is at {org.apache.pulsar.broker.service.persistent.Persistentdispatchermultipleconsumers#removeconsumer}. Nothing is done specifically, but the log is printed. Because there are multiple identical consumers that can only be successfully removed once, the subscription exists, but the channel is closed, so in {io.streamnative.pulsar.handlers.amqp.Amqpoutputconverter#writeframe}, {getctx().writeAndFlush(frame);} Write failed because the channel is closed and cannot be written.



Question 2.

In {io.streamnative.pulsar.handlers.amqp.AmqpConsumer},
We should override Consumer#isWritable(), and check whether the channel of AMQP is writable











