### PR TITLE
Fix - Add queue to exchange when recover from topic.

### DIFF
--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/impl/PersistentQueue.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/impl/PersistentQueue.java
@@ -135,6 +135,7 @@ public class PersistentQueue extends AbstractAmqpQueue {
                 messageRouter.setArguments(arguments);
                 messageRouter.setBindingKeys(bindingKeys);
                 routers.put(exchangeName, messageRouter);
+                amqpExchange.addQueue(this);
             });
         });
     }


### PR DESCRIPTION
### Motivation

Add queue to exchange when recover from topic.

Think that
- Receive cmd `AmqpChannel -> receiveBasicPublish`.
- Get or create queue `QueueContainer -> asyncGetQueue`.
- Recover from topic `PersistentTopic -> recoverRoutersFromQueueProperties`, and add to routers.
- Then queue would be never add to exchange.



```
AmqpChannel -> receiveBasicPublish

if (amqpQueue.getRouter(AbstractAmqpExchange.DEFAULT_EXCHANGE_DURABLE) == null) {
    amqpQueue.bindExchange(amqpExchange,
            AbstractAmqpMessageRouter.generateRouter(AmqpExchange.Type.Direct),
            routingKey.toString(), null);
}
```

So, we should add queue after add to routers.

### Modifications


### Verifying this change


### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
  
- [x] `no-need-doc`