### PR TITLE
bugfix: amqpListeners cannot be configured dynamically.

### DIFF
--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpProtocolHandler.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpProtocolHandler.java
@@ -166,7 +166,7 @@ public class AmqpProtocolHandler implements ProtocolHandler {
     public static String getAppliedAmqpListeners(AmqpServiceConfiguration configuration) {
         String amqpListeners = configuration.getAmqpListeners();
         if (amqpListeners == null) {
-            String fullyHostName = ServiceConfigurationUtils.getDefaultOrConfiguredAddress(amqpListeners);
+            String fullyHostName = ServiceConfigurationUtils.unsafeLocalhostResolve();
             return amqpUrl(fullyHostName, 5672);
         }
         return amqpListeners;

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpServiceConfiguration.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpServiceConfiguration.java
@@ -58,10 +58,10 @@ public class AmqpServiceConfiguration extends ServiceConfiguration {
 
     @FieldContext(
             category = CATEGORY_AMQP,
-            required = true,
+            required = false,
             doc = "The namespace used for storing Amqp metadata topics"
     )
-    private String amqpListeners = "amqp://127.0.0.1:5672";
+    private String amqpListeners;
 
     @FieldContext(
         category = CATEGORY_AMQP,


### PR DESCRIPTION
Fixes Issue: #527 

### Motivation

In version 2.9.*, if amqpListeners cannot be configured dynamically, Aop Proxy will not be available. When YAML is deployed in K8S, StatefulSet shares the ConfigMap configuration. Each Pod configuration is the same and cannot be configured dynamically. The production client generates the following error:
```
java.net.SocketTimeoutException: Timeout during Connection negotiation
	at com.rabbitmq.client.impl.AMQConnection.handleSocketTimeout(AMQConnection.java:815)
	at com.rabbitmq.client.impl.AMQConnection.readFrame(AMQConnection.java:727)
	at com.rabbitmq.client.impl.AMQConnection.access$300(AMQConnection.java:48)
	at com.rabbitmq.client.impl.AMQConnection$MainLoop.run(AMQConnection.java:646)
	at java.lang.Thread.run(Thread.java:748)
java.io.IOException
	at com.rabbitmq.client.impl.AMQChannel.wrap(AMQChannel.java:129)
	at com.rabbitmq.client.impl.AMQChannel.wrap(AMQChannel.java:125)
	at com.rabbitmq.client.impl.AMQChannel.exnWrappingRpc(AMQChannel.java:147)
	at com.rabbitmq.client.impl.AMQConnection.start(AMQConnection.java:423)
	at com.rabbitmq.client.impl.recovery.RecoveryAwareAMQConnectionFactory.newConnection(RecoveryAwareAMQConnectionFactory.java:64)
	at com.rabbitmq.client.impl.recovery.AutorecoveringConnection.init(AutorecoveringConnection.java:156)
	at com.rabbitmq.client.ConnectionFactory.newConnection(ConnectionFactory.java:1110)
	at com.rabbitmq.client.ConnectionFactory.newConnection(ConnectionFactory.java:1067)
	at com.rabbitmq.client.ConnectionFactory.newConnection(ConnectionFactory.java:1025)
	at com.rabbitmq.client.ConnectionFactory.newConnection(ConnectionFactory.java:1187)
	at com.example.rabbitmq.client.demo.Producer.main(Producer.java:20)
Caused by: com.rabbitmq.client.ShutdownSignalException: connection error
	at com.rabbitmq.utility.ValueOrException.getValue(ValueOrException.java:66)
	at com.rabbitmq.utility.BlockingValueOrException.uninterruptibleGetValue(BlockingValueOrException.java:36)
	at com.rabbitmq.client.impl.AMQChannel$BlockingRpcContinuation.getReply(AMQChannel.java:502)
	at com.rabbitmq.client.impl.AMQChannel.privateRpc(AMQChannel.java:293)
	at com.rabbitmq.client.impl.AMQChannel.exnWrappingRpc(AMQChannel.java:141)
	... 8 more
Caused by: java.net.SocketTimeoutException: Timeout during Connection negotiation
	at com.rabbitmq.client.impl.AMQConnection.handleSocketTimeout(AMQConnection.java:815)
	at com.rabbitmq.client.impl.AMQConnection.readFrame(AMQConnection.java:727)
	at com.rabbitmq.client.impl.AMQConnection.access$300(AMQConnection.java:48)
	at com.rabbitmq.client.impl.AMQConnection$MainLoop.run(AMQConnection.java:646)
	at java.lang.Thread.run(Thread.java:748)
```

### Modifications

Get the fully qualified name of the host dynamically at broker startup.
