### PR TITLE
Fix exclusive consume problem

### DIFF
--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpConsumer.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpConsumer.java
@@ -17,7 +17,6 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelPromise;
 import io.netty.util.concurrent.Future;
 import io.streamnative.pulsar.handlers.amqp.utils.MessageConvertUtils;
-import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/AmqpTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/AmqpTestBase.java
@@ -101,7 +101,7 @@ public class AmqpTestBase extends AmqpProtocolHandlerTestBase {
         return connectionFactory.newConnection();
     }
 
-    protected void basicDirectConsume(String vhost) throws Exception {
+    protected void basicDirectConsume(String vhost, boolean exclusiveConsume) throws Exception {
         String exchangeName = randExName();
         String routingKey = "test.key";
         String queueName = randQuName();
@@ -117,7 +117,7 @@ public class AmqpTestBase extends AmqpProtocolHandlerTestBase {
         CountDownLatch countDownLatch = new CountDownLatch(messageCnt);
 
         AtomicInteger consumeIndex = new AtomicInteger(0);
-        channel.basicConsume(queueName, false,
+        channel.basicConsume(queueName, false, null, false, exclusiveConsume, null,
                 new DefaultConsumer(channel) {
                     @Override
                     public void handleDelivery(String consumerTag,

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/AmqpTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/AmqpTestBase.java
@@ -117,7 +117,7 @@ public class AmqpTestBase extends AmqpProtocolHandlerTestBase {
         CountDownLatch countDownLatch = new CountDownLatch(messageCnt);
 
         AtomicInteger consumeIndex = new AtomicInteger(0);
-        channel.basicConsume(queueName, false, null, false, exclusiveConsume, null,
+        channel.basicConsume(queueName, false, "", false, exclusiveConsume, null,
                 new DefaultConsumer(channel) {
                     @Override
                     public void handleDelivery(String consumerTag,

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/PulsarDeduplicationWorkAroundTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/PulsarDeduplicationWorkAroundTest.java
@@ -33,7 +33,7 @@ public class PulsarDeduplicationWorkAroundTest extends AmqpTestBase {
 
     @Test(timeOut = 1000 * 5)
     public void basicConsumeCase() throws Exception {
-        basicDirectConsume("vhost1");
+        basicDirectConsume("vhost1", false);
     }
 
 }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/RabbitMQMessagingTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/RabbitMQMessagingTest.java
@@ -383,7 +383,7 @@ public class RabbitMQMessagingTest extends AmqpTestBase {
         } catch (InterruptedException e) {
             // ignored
         }
-        Assert.assertEquals(messageCnt, consumeIndex2.get());
+        Assert.assertTrue(consumeIndex2.get() >= messageCnt);
         channel3.close();
         conn.close();
     }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/RabbitMQMessagingTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/RabbitMQMessagingTest.java
@@ -79,7 +79,7 @@ public class RabbitMQMessagingTest extends AmqpTestBase {
 
     @Test(timeOut = 1000 * 5, dataProvider = "consumeExclusiveProvider")
     public void basicConsumeCase(boolean consumeExclusive) throws Exception {
-        basicDirectConsume("default", consumeExclusive);
+        basicDirectConsume("vhost1", consumeExclusive);
     }
 
     @Test(timeOut = 1000 * 5)

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/RabbitMQMessagingTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/RabbitMQMessagingTest.java
@@ -41,6 +41,7 @@ import org.apache.pulsar.client.api.SubscriptionInitialPosition;
 import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 /**
@@ -48,6 +49,13 @@ import org.testng.annotations.Test;
  */
 @Slf4j
 public class RabbitMQMessagingTest extends AmqpTestBase {
+
+    @DataProvider(name = "consumeExclusiveProvider")
+    public Object[][] consumeExclusiveProvider() {
+        return new Object[][]{
+                { false }, { true }
+        };
+    }
 
     @Test(timeOut = 1000 * 5)
     public void basicConsumeCaseWithNewAddedHost() throws Exception {
@@ -66,12 +74,12 @@ public class RabbitMQMessagingTest extends AmqpTestBase {
         if (unknownConn.isOpen()) {
             unknownConn.close();
         }
-        basicDirectConsume(newAddedVhost);
+        basicDirectConsume(newAddedVhost, false);
     }
 
-    @Test(timeOut = 1000 * 5)
-    public void basicConsumeCase() throws Exception {
-        basicDirectConsume("vhost1");
+    @Test(timeOut = 1000 * 5, dataProvider = "consumeExclusiveProvider")
+    public void basicConsumeCase(boolean consumeExclusive) throws Exception {
+        basicDirectConsume("default", consumeExclusive);
     }
 
     @Test(timeOut = 1000 * 5)

--- a/tests/src/test/resources/log4j2.xml
+++ b/tests/src/test/resources/log4j2.xml
@@ -40,7 +40,7 @@
             <AppenderRef ref="Console" />
         </Root>
         <Logger name="org.eclipse.jetty" level="info"/>
-        <Logger name="io.streamnative" level="debug"/>
+        <Logger name="io.streamnative" level="info"/>
         <Logger name="org.apache.pulsar" level="info"/>
         <Logger name="org.apache.bookkeeper" level="info"/>
     </Loggers>


### PR DESCRIPTION
Master Issue: #572 

### Motivation


If using the basic exclusive consume messages, the AoP will encounter an NPE exception.

```
channel.basicConsume(queueName, false, "", false, true, null,
        new DefaultConsumer(channel) {
            @Override
            public void handleDelivery(String consumerTag,
                                       Envelope envelope,
                                       AMQP.BasicProperties properties,
                                       byte[] body) throws IOException {
                long deliveryTag = envelope.getDeliveryTag();
                Assert.assertEquals(new String(body), "Hello, world! - " + consumeIndex.getAndIncrement());
                channel.basicAck(deliveryTag, false);
            }
        });

```

```
19:07:56.969 [pulsar-ph-amqp-34-2:io.streamnative.pulsar.handlers.amqp.AmqpConnection@500] DEBUG io.streamnative.pulsar.handlers.amqp.AmqpConnection - send: [CompositeAMQBodyBlock methodBody=[EncodedDeliveryBody underlyingBody: null], headerBody=ContentHeaderBody{classId=60, weight=0, bodySize=17, properties=reply-to = null,propertyFlags = 8192,ApplicationID = null,ClusterID = null,UserId = null,JMSMessageID = null,JMSCorrelationID = null,JMSDeliveryMode = 0,JMSExpiration = 0,JMSPriority = 0,JMSTimestamp = 0,JMSType = null,contentType = null}, contentBody=[MessageContentSourceBody, length: 17], channel=1]
19:07:56.969 [broker-topic-workers-OrderedScheduler-4-0:org.apache.bookkeeper.common.util.SafeRunnable@38] ERROR org.apache.bookkeeper.common.util.SafeRunnable - Unexpected throwable caught 
java.lang.NullPointerException: Cannot invoke "io.netty.util.concurrent.Future.addListener(io.netty.util.concurrent.GenericFutureListener)" because the return value of "org.apache.pulsar.broker.service.Consumer.sendMessages(java.util.List, org.apache.pulsar.broker.service.EntryBatchSizes, org.apache.pulsar.broker.service.EntryBatchIndexesAcks, int, long, long, org.apache.pulsar.broker.service.RedeliveryTracker, long)" is null
	at org.apache.pulsar.broker.service.persistent.PersistentDispatcherSingleActiveConsumer.dispatchEntriesToConsumer(PersistentDispatcherSingleActiveConsumer.java:218) ~[pulsar-broker-2.10.0.0-rc9.jar:2.10.0.0-rc9]
	at org.apache.pulsar.broker.service.persistent.PersistentDispatcherSingleActiveConsumer.internalReadEntriesComplete(PersistentDispatcherSingleActiveConsumer.java:207) ~[pulsar-broker-2.10.0.0-rc9.jar:2.10.0.0-rc9]
	at org.apache.pulsar.broker.service.persistent.PersistentDispatcherSingleActiveConsumer.lambda$readEntriesComplete$1(PersistentDispatcherSingleActiveConsumer.java:146) ~[pulsar-broker-2.10.0.0-rc9.jar:2.10.0.0-rc9]
	at org.apache.bookkeeper.mledger.util.SafeRun$1.safeRun(SafeRun.java:32) ~[managed-ledger-2.10.0.0-rc9.jar:2.10.0.0-rc9]
	at org.apache.bookkeeper.common.util.SafeRunnable.run(SafeRunnable.java:36) [bookkeeper-common-4.14.4.jar:4.14.4]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539) [?:?]
	at java.util.concurrent.FutureTask.run$$$capture(FutureTask.java:264) [?:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java) [?:?]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304) [?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) [?:?]
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) [netty-common-4.1.74.Final.jar:4.1.74.Final]
	at java.lang.Thread.run(Thread.java:833) [?:?]
```

### Modifications

Return future objects when sending messages.

### Verifying this change

Add unit test to verify exclusive consumption operation.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)
