### PR TITLE
bugfix: High Memory usage caused memory overflow.

### DIFF
--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpBrokerDecoder.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpBrokerDecoder.java
@@ -14,7 +14,6 @@
 package io.streamnative.pulsar.handlers.amqp;
 
 import java.io.IOException;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.qpid.server.bytebuffer.QpidByteBuffer;
 import org.apache.qpid.server.protocol.v0_8.AMQFrameDecodingException;
 import org.apache.qpid.server.protocol.v0_8.ServerDecoder;
@@ -25,7 +24,6 @@ import org.apache.qpid.server.protocol.v0_8.transport.ServerMethodProcessor;
 /**
  * Amqp broker decoder for amqp protocol requests decoding.
  */
-@Slf4j
 public class AmqpBrokerDecoder extends ServerDecoder {
 
     private static final int bufferSize = 4 * 1024;

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpBrokerDecoder.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpBrokerDecoder.java
@@ -50,16 +50,14 @@ public class AmqpBrokerDecoder extends ServerDecoder {
         int messageSize = buf.remaining();
         if (netInputBuffer.remaining() < messageSize) {
             QpidByteBuffer oldBuffer = netInputBuffer;
-            boolean oldBufferFlag = false;
             if (oldBuffer.position() != 0) {
                 oldBuffer.limit(oldBuffer.position());
                 oldBuffer.slice();
                 oldBuffer.flip();
-                oldBufferFlag = true;
-            }
-            netInputBuffer = QpidByteBuffer.allocateDirect(bufferSize + oldBuffer.remaining() + messageSize);
-            if (oldBufferFlag) {
+                netInputBuffer = QpidByteBuffer.allocateDirect(bufferSize + oldBuffer.remaining() + messageSize);
                 netInputBuffer.put(oldBuffer);
+            } else {
+                netInputBuffer = QpidByteBuffer.allocateDirect(bufferSize + messageSize);
             }
         }
         netInputBuffer.put(buf);


### PR DESCRIPTION
Master Issue: #589

### Motivation

After each client is connected to the broker, 4MB of memory is allocated for each connection in `io/streamnative/pulsar/handlers/amqp/AmqpBrokerDecoder.java`, which is high when there are too many broker connections. Increasing the number of connections eventually leads to OOM.

### Modifications

The current memory allocation strategy is that messages smaller than 4K are initialized at 4K per connection and messages larger than 4K are allocated on demand. The previous connection was initialized with a size of 4M.
