### PR TITLE
feat: add token authentication support

### DIFF
--- a/amqp-client-auth/pom.xml
+++ b/amqp-client-auth/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>pulsar-protocol-handler-amqp-parent</artifactId>
+        <groupId>io.streamnative.pulsar.handlers</groupId>
+        <version>2.9.1.3</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>amqp-client-auth</artifactId>
+
+    <properties>
+        <jjwt.version>0.11.5</jjwt.version>
+        <awaitility.version>4.2.0</awaitility.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.rabbitmq</groupId>
+            <artifactId>amqp-client</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-api</artifactId>
+            <version>${jjwt.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-impl</artifactId>
+            <version>${jjwt.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>${awaitility.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/amqp-client-auth/src/main/java/io/streamnative/rabbitmq/authentication/MechanismException.java
+++ b/amqp-client-auth/src/main/java/io/streamnative/rabbitmq/authentication/MechanismException.java
@@ -1,0 +1,23 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.rabbitmq.authentication;
+
+/**
+ * MechanismException provides an exception for mechanism.
+ */
+public class MechanismException extends Exception {
+    public MechanismException(String message) {
+        super(message);
+    }
+}

--- a/amqp-client-auth/src/main/java/io/streamnative/rabbitmq/authentication/TokenCredentialsProvider.java
+++ b/amqp-client-auth/src/main/java/io/streamnative/rabbitmq/authentication/TokenCredentialsProvider.java
@@ -1,0 +1,76 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.rabbitmq.authentication;
+
+import com.rabbitmq.client.impl.CredentialsProvider;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Header;
+import io.jsonwebtoken.Jwt;
+import io.jsonwebtoken.Jwts;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+import java.util.function.Supplier;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * TokenCredentialsProvider provides a token credential provider that supports refresh.
+ */
+@Slf4j
+public class TokenCredentialsProvider implements CredentialsProvider {
+    private final Supplier<String> tokenSupplier;
+    private String token;
+    private Jwt<Header, Claims> jwt;
+
+    public TokenCredentialsProvider(Supplier<String> tokenSupplier) {
+        load(tokenSupplier);
+        this.tokenSupplier = tokenSupplier;
+    }
+
+    private void load(Supplier<String> tokenSupplier) {
+        String token = tokenSupplier.get();
+        int i = token.lastIndexOf('.');
+        String withoutSignature = token.substring(0, i + 1);
+        this.jwt = Jwts.parserBuilder().build().parseClaimsJwt(withoutSignature);
+        this.token = token;
+    }
+
+    @Override
+    public String getUsername() {
+        return null;
+    }
+
+    @Override
+    public String getPassword() {
+        return token;
+    }
+
+    @Override
+    public Duration getTimeBeforeExpiration() {
+        Date expiration = jwt.getBody().getExpiration();
+        if (expiration == null) {
+            return null;
+        }
+        return Duration.between(expiration.toInstant(), Instant.now());
+    }
+
+    @Override
+    public void refresh() {
+        try {
+            load(tokenSupplier);
+        } catch (Exception e) {
+            log.error("Failed to refresh token", e);
+        }
+    }
+}

--- a/amqp-client-auth/src/main/java/io/streamnative/rabbitmq/authentication/TokenSaslConfig.java
+++ b/amqp-client-auth/src/main/java/io/streamnative/rabbitmq/authentication/TokenSaslConfig.java
@@ -1,0 +1,50 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.rabbitmq.authentication;
+
+import com.rabbitmq.client.LongString;
+import com.rabbitmq.client.SaslConfig;
+import com.rabbitmq.client.SaslMechanism;
+import com.rabbitmq.client.impl.LongStringHelper;
+import java.util.Arrays;
+import lombok.SneakyThrows;
+import org.apache.commons.lang3.ArrayUtils;
+
+/**
+ * TokenSaslConfig provides a sasl config for OAuth2 or JWT.
+ */
+public class TokenSaslConfig implements SaslConfig {
+    private static final String mechanism = "token";
+
+    @SneakyThrows
+    @Override
+    public SaslMechanism getSaslMechanism(String[] mechanisms) {
+        if (ArrayUtils.isEmpty(mechanisms) || Arrays.stream(mechanisms).noneMatch(n -> n.equals(mechanism))) {
+            throw new MechanismException(String.format("%s mechanism is not supported, available mechanisms: %s",
+                    mechanism, Arrays.toString(mechanisms)));
+        }
+
+        return new SaslMechanism() {
+            @Override
+            public String getName() {
+                return mechanism;
+            }
+
+            @Override
+            public LongString handleChallenge(LongString challenge, String username, String password) {
+                return LongStringHelper.asLongString(password);
+            }
+        };
+    }
+}

--- a/amqp-client-auth/src/main/java/io/streamnative/rabbitmq/authentication/package-info.java
+++ b/amqp-client-auth/src/main/java/io/streamnative/rabbitmq/authentication/package-info.java
@@ -1,0 +1,14 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.rabbitmq.authentication;

--- a/amqp-client-auth/src/test/java/io/streamnative/rabbitmq/authentication/TokenSaslConfigTest.java
+++ b/amqp-client-auth/src/test/java/io/streamnative/rabbitmq/authentication/TokenSaslConfigTest.java
@@ -1,0 +1,79 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.rabbitmq.authentication;
+
+import static org.awaitility.Awaitility.await;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
+
+import com.rabbitmq.client.LongString;
+import com.rabbitmq.client.SaslConfig;
+import com.rabbitmq.client.SaslMechanism;
+import com.rabbitmq.client.impl.CredentialsProvider;
+import com.rabbitmq.client.impl.LongStringHelper;
+import io.jsonwebtoken.SignatureAlgorithm;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import javax.crypto.SecretKey;
+import org.apache.pulsar.broker.authentication.utils.AuthTokenUtils;
+import org.testng.annotations.Test;
+
+/**
+ * TokenSaslConfigTest tests {@link io.streamnative.rabbitmq.authentication.TokenSaslConfig}.
+ */
+public class TokenSaslConfigTest {
+    private final SecretKey secretKey = AuthTokenUtils.createSecretKey(SignatureAlgorithm.HS256);
+
+    @Test
+    public void testTokenSaslConfig() {
+        SaslConfig saslConfig = new TokenSaslConfig();
+        SaslMechanism saslMechanism = saslConfig.getSaslMechanism(new String[]{"PLAIN", "token"});
+        assertEquals(saslMechanism.getName(), "token");
+
+        String token = "your token";
+        LongString data = saslMechanism.handleChallenge(null, null, token);
+        assertEquals(data, LongStringHelper.asLongString(token));
+    }
+
+    @Test
+    public void testUnSupportMechanism() {
+        SaslConfig saslConfig = new TokenSaslConfig();
+        assertThrows(MechanismException.class, () -> saslConfig.getSaslMechanism(new String[]{"PLAIN"}));
+    }
+
+    @Test
+    public void testGetTimeBeforeExpiration() {
+        String token = AuthTokenUtils.createToken(secretKey, "client",
+                Optional.of(Date.from(Instant.now().plusSeconds(5))));
+        CredentialsProvider c = new TokenCredentialsProvider(() -> token);
+        Duration duration = c.getTimeBeforeExpiration();
+        assertNotNull(duration);
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
+            assertTrue(c.getTimeBeforeExpiration().getSeconds() >= 0);
+        });
+    }
+
+    @Test
+    public void testNullGetTimeBeforeExpiration() {
+        String token = AuthTokenUtils.createToken(secretKey, "client", Optional.empty());
+        CredentialsProvider c = new TokenCredentialsProvider(() -> token);
+        assertNull(c.getTimeBeforeExpiration());
+    }
+}

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpBrokerService.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpBrokerService.java
@@ -16,6 +16,7 @@ package io.streamnative.pulsar.handlers.amqp;
 
 import lombok.Getter;
 import org.apache.pulsar.broker.PulsarService;
+import org.apache.pulsar.broker.authentication.AuthenticationService;
 
 /**
  * AMQP broker related.
@@ -54,5 +55,13 @@ public class AmqpBrokerService {
         this.exchangeService = new ExchangeServiceImpl(exchangeContainer);
         this.queueService = new QueueServiceImpl(exchangeContainer, queueContainer);
         this.connectionContainer = connectionContainer;
+    }
+
+    public boolean isAuthenticationEnabled() {
+        return pulsarService.getConfiguration().isAuthenticationEnabled();
+    }
+
+    public AuthenticationService getAuthenticationService() {
+        return pulsarService.getBrokerService().getAuthenticationService();
     }
 }

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpClientDecoder.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpClientDecoder.java
@@ -14,6 +14,7 @@
 package io.streamnative.pulsar.handlers.amqp;
 
 import java.nio.ByteBuffer;
+import java.util.Objects;
 import org.apache.qpid.server.bytebuffer.QpidByteBuffer;
 import org.apache.qpid.server.protocol.ProtocolVersion;
 import org.apache.qpid.server.protocol.v0_8.AMQDecoder;
@@ -141,7 +142,7 @@ public class AmqpClientDecoder extends AMQDecoder<ClientMethodProcessor<? extend
                     ConnectionRedirectBody.process(in, methodProcessor);
                     break;
                 case 0x000a0032:
-                    if (methodProcessor.getProtocolVersion().equals(ProtocolVersion.v0_8))
+                    if (Objects.equals(methodProcessor.getProtocolVersion(), ProtocolVersion.v0_8))
                     {
                         ConnectionRedirectBody.process(in, methodProcessor);
                     }
@@ -151,7 +152,7 @@ public class AmqpClientDecoder extends AMQDecoder<ClientMethodProcessor<? extend
                     }
                     break;
                 case 0x000a0033:
-                    if (methodProcessor.getProtocolVersion().equals(ProtocolVersion.v0_8))
+                    if (Objects.equals(methodProcessor.getProtocolVersion(), ProtocolVersion.v0_8))
                     {
                         throw newUnknownMethodException(classId, methodId,
                                                         methodProcessor.getProtocolVersion());
@@ -162,7 +163,7 @@ public class AmqpClientDecoder extends AMQDecoder<ClientMethodProcessor<? extend
                     }
                     break;
                 case 0x000a003c:
-                    if (methodProcessor.getProtocolVersion().equals(ProtocolVersion.v0_8))
+                    if (Objects.equals(methodProcessor.getProtocolVersion(), ProtocolVersion.v0_8))
                     {
                         ConnectionCloseBody.process(in, methodProcessor);
                     }
@@ -173,7 +174,7 @@ public class AmqpClientDecoder extends AMQDecoder<ClientMethodProcessor<? extend
                     }
                     break;
                 case 0x000a003d:
-                    if (methodProcessor.getProtocolVersion().equals(ProtocolVersion.v0_8))
+                    if (Objects.equals(methodProcessor.getProtocolVersion(), ProtocolVersion.v0_8))
                     {
                         methodProcessor.receiveConnectionCloseOk();
                     }

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/proxy/ProxyConnection.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/proxy/ProxyConnection.java
@@ -172,7 +172,7 @@ public class ProxyConnection extends ChannelInboundHandlerAdapter implements
                     (short) pv.getActualMinorVersion(),
                     null,
                     // TODO temporary modification
-                    "PLAIN".getBytes(US_ASCII),
+                    "PLAIN token".getBytes(US_ASCII),
                     "en_US".getBytes(US_ASCII));
             writeFrame(responseBody.generateFrame(0));
         } catch (QpidException e) {

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/proxy/ProxyHandler.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/proxy/ProxyHandler.java
@@ -33,9 +33,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.qpid.server.protocol.ProtocolVersion;
 import org.apache.qpid.server.protocol.v0_8.AMQShortString;
 import org.apache.qpid.server.protocol.v0_8.FieldTable;
+import org.apache.qpid.server.protocol.v0_8.transport.AMQFrame;
 import org.apache.qpid.server.protocol.v0_8.transport.AMQMethodBody;
 import org.apache.qpid.server.protocol.v0_8.transport.ClientChannelMethodProcessor;
 import org.apache.qpid.server.protocol.v0_8.transport.ClientMethodProcessor;
+import org.apache.qpid.server.protocol.v0_8.transport.ConnectionCloseBody;
 import org.apache.qpid.server.protocol.v0_8.transport.ProtocolInitiation;
 
 /**
@@ -220,10 +222,15 @@ public class ProxyHandler {
         }
 
         @Override
-        public void receiveConnectionClose(int i, AMQShortString amqShortString, int i1, int i2) {
+        public void receiveConnectionClose(int replyCode, AMQShortString replyText,
+                                           int classId, int methodId) {
             if (log.isDebugEnabled()) {
                 log.debug("ProxyBackendHandler [receiveConnectionClose]");
             }
+
+            AMQFrame frame = new AMQFrame(0,
+                    new ConnectionCloseBody(getProtocolVersion(), replyCode, replyText, classId, methodId));
+            clientChannel.writeAndFlush(frame);
         }
 
         @Override
@@ -231,6 +238,7 @@ public class ProxyHandler {
             if (log.isDebugEnabled()) {
                 log.debug("ProxyBackendHandler [receiveConnectionCloseOk]");
             }
+            close();
         }
 
         @Override

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,7 @@
     <module>amqp-impl</module>
     <module>tests</module>
     <module>tests-qpid-jms-client</module>
+    <module>amqp-client-auth</module>
   </modules>
 
   <!-- dependency definitions -->
@@ -90,6 +91,11 @@
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-annotations</artifactId>
         <version>${spotbugs-annotations.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.rabbitmq</groupId>
+        <artifactId>amqp-client</artifactId>
+        <version>${rabbitmq.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -99,7 +99,13 @@
       <version>${hamcrest-version}</version>
       <scope>test</scope>
     </dependency>
-    <!-- jms test -->
+
+    <dependency>
+      <groupId>io.streamnative.pulsar.handlers</groupId>
+      <artifactId>amqp-client-auth</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/AmqpTokenAuthenticationTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/AmqpTokenAuthenticationTestBase.java
@@ -1,0 +1,97 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.amqp;
+
+import com.google.common.collect.Sets;
+import io.jsonwebtoken.SignatureAlgorithm;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
+import javax.crypto.SecretKey;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.broker.authentication.AuthenticationProviderToken;
+import org.apache.pulsar.broker.authentication.utils.AuthTokenUtils;
+import org.apache.pulsar.client.impl.auth.AuthenticationToken;
+import org.apache.pulsar.common.naming.NamespaceName;
+import org.apache.pulsar.common.naming.TopicDomain;
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.policies.data.ClusterData;
+import org.apache.pulsar.common.policies.data.TenantInfo;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+
+/**
+ * Base authentication test class for RabbitMQ Client.
+ */
+@Slf4j
+public class AmqpTokenAuthenticationTestBase extends AmqpProtocolHandlerTestBase {
+    protected final SecretKey secretKey = AuthTokenUtils.createSecretKey(SignatureAlgorithm.HS256);
+    protected final String clientToken = AuthTokenUtils.createToken(secretKey, "client", Optional.empty());
+
+    @BeforeClass
+    @Override
+    public void setup() throws Exception {
+        conf.setAuthenticationEnabled(true);
+        conf.setAuthenticationProviders(Sets.newHashSet(AuthenticationProviderToken.class.getName()));
+
+        Properties properties = new Properties();
+        properties.setProperty("tokenSecretKey", AuthTokenUtils.encodeKeyBase64(secretKey));
+        conf.setProperties(properties);
+
+        conf.setBrokerClientAuthenticationPlugin(AuthenticationToken.class.getName());
+        conf.setBrokerClientAuthenticationParameters(clientToken);
+
+        super.internalSetup();
+        log.info("success internal setup");
+
+        ClusterData clusterData = ClusterData.builder()
+                .serviceUrl("http://127.0.0.1:" + getBrokerWebservicePortList().get(0))
+                .build();
+        if (!admin.clusters().getClusters().contains(configClusterName)) {
+            // so that clients can test short names
+            admin.clusters().createCluster(configClusterName, clusterData);
+        } else {
+            admin.clusters().updateCluster(configClusterName, clusterData);
+        }
+
+        TenantInfo tenantInfo = TenantInfo.builder()
+                .adminRoles(Sets.newHashSet("appid1", "appid2"))
+                .allowedClusters(Sets.newHashSet("test"))
+                .build();
+        if (!admin.tenants().getTenants().contains("public")) {
+            admin.tenants().createTenant("public", tenantInfo);
+        } else {
+            admin.tenants().updateTenant("public", tenantInfo);
+        }
+
+        List<String> vhostList = Arrays.asList("vhost1", "vhost2", "vhost3");
+        for (String vhost : vhostList) {
+            String ns = "public/" + vhost;
+            if (!admin.namespaces().getNamespaces("public").contains(ns)) {
+                admin.namespaces().createNamespace(ns, 1);
+                admin.lookups().lookupTopicAsync(TopicName.get(TopicDomain.persistent.value(),
+                        NamespaceName.get(ns), "__lookup__").toString());
+            }
+        }
+
+        checkPulsarServiceState();
+    }
+
+    @AfterClass
+    @Override
+    public void cleanup() throws Exception {
+        super.internalCleanup();
+    }
+}

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/authentication/TokenAuthenticationTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/authentication/TokenAuthenticationTest.java
@@ -1,0 +1,102 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.amqp.rabbitmq.authentication;
+
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Connection;
+import com.rabbitmq.client.ConnectionFactory;
+import com.rabbitmq.client.LongString;
+import com.rabbitmq.client.PossibleAuthenticationFailureException;
+import com.rabbitmq.client.SaslMechanism;
+import com.rabbitmq.client.impl.LongStringHelper;
+import io.streamnative.pulsar.handlers.amqp.AmqpTokenAuthenticationTestBase;
+import io.streamnative.rabbitmq.authentication.TokenCredentialsProvider;
+import io.streamnative.rabbitmq.authentication.TokenSaslConfig;
+import java.io.IOException;
+import java.util.concurrent.TimeoutException;
+import lombok.Cleanup;
+import org.testng.annotations.Test;
+
+/**
+ * TokenAuthenticationTest tests the token authentication.
+ */
+public class TokenAuthenticationTest extends AmqpTokenAuthenticationTestBase {
+    private void testConnect(int port) throws Exception {
+        ConnectionFactory connectionFactory = new ConnectionFactory();
+        connectionFactory.setHost("localhost");
+        connectionFactory.setPort(port);
+        connectionFactory.setVirtualHost("vhost1");
+        connectionFactory.setSaslConfig(new TokenSaslConfig());
+        connectionFactory.setCredentialsProvider(new TokenCredentialsProvider(() -> clientToken));
+        @Cleanup
+        Connection connection = connectionFactory.newConnection();
+        @Cleanup
+        Channel ignored = connection.createChannel();
+    }
+
+    @Test
+    public void testConnectToBroker() throws Exception {
+        testConnect(getAmqpBrokerPortList().get(0));
+    }
+
+    @Test
+    public void testConnectToProxy() throws Exception {
+        testConnect(getAopProxyPortList().get(0));
+    }
+
+    private void testConnectWithInvalidToken(int port, boolean isProxy) throws IOException, TimeoutException {
+        ConnectionFactory connectionFactory = new ConnectionFactory();
+        connectionFactory.setHost("localhost");
+        connectionFactory.setPort(port);
+        connectionFactory.setVirtualHost("vhost1");
+        connectionFactory.setSaslConfig(mechanisms -> {
+            String mechanism = "token";
+            return new SaslMechanism() {
+                @Override
+                public String getName() {
+                    return mechanism;
+                }
+
+                @Override
+                public LongString handleChallenge(LongString challenge, String username, String password) {
+                    return LongStringHelper.asLongString("");
+                }
+            };
+        });
+
+        Exception exception;
+        if (isProxy) {
+            exception = expectThrows(IOException.class,
+                    connectionFactory::newConnection);
+        } else {
+            exception = expectThrows(PossibleAuthenticationFailureException.class,
+                    connectionFactory::newConnection);
+        }
+
+        assertTrue(exception.getCause().getMessage().contains("No authentication data provided"));
+    }
+
+    @Test
+    public void testConnectToBrokerWithInvalidToken() throws IOException, TimeoutException {
+        testConnectWithInvalidToken(getAmqpBrokerPortList().get(0), false);
+    }
+
+    @Test
+    public void testConnectToProxyWithInvalidToken() throws IOException, TimeoutException {
+        testConnectWithInvalidToken(getAopProxyPortList().get(0), true);
+    }
+}


### PR DESCRIPTION
Signed-off-by: Zixuan Liu <nodeces@gmail.com>

Fixes #579 

### Motivation

Add token authentication support, this also applies to OAuth2 authentication.

### Modifications

- Add `amqp-client-auth` to provide the JWT authentication
- In the `receiveProtocolHeader` method tells the authentication method name supported to the client 
- In the `receiveConnectionStartOk` providers authenticate the data provided by the client

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

- [x] `doc-required` 
  
### TODO
- [ ] Add authentication documentation
- [x] Implement the authentication provider in go-client - https://github.com/streamnative/aop-amqp091-auth-go
- [x] Add authentication service to proxy module