### PR TITLE
bugfix: Default echange consume failed, when broker restart.

### DIFF
--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AbstractAmqpExchange.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AbstractAmqpExchange.java
@@ -43,6 +43,17 @@ public abstract class AbstractAmqpExchange implements AmqpExchange {
     }
 
     @Override
+    public AmqpQueue getQueue(String queueName) {
+        AmqpQueue queue = null;
+        for (AmqpQueue q : queues) {
+            if (q.getName().equals(queueName)) {
+                queue = q;
+            }
+        }
+        return queue;
+    }
+
+    @Override
     public void removeQueue(AmqpQueue queue) {
         queues.remove(queue);
     }

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpChannel.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpChannel.java
@@ -334,7 +334,8 @@ public class AmqpChannel implements ServerChannelMethodProcessor {
                                 return;
                             } else {
                                 // bind to default exchange.
-                                if (amqpQueue.getRouter(AbstractAmqpExchange.DEFAULT_EXCHANGE_DURABLE) == null) {
+                                if (amqpQueue.getRouter(AbstractAmqpExchange.DEFAULT_EXCHANGE_DURABLE) == null
+                                        || amqpExchange.getQueue(queueName) == null) {
                                     amqpQueue.bindExchange(amqpExchange,
                                             AbstractAmqpMessageRouter.generateRouter(AmqpExchange.Type.Direct),
                                             routingKey.toString(), null);

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpExchange.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpExchange.java
@@ -134,6 +134,13 @@ public interface AmqpExchange {
     void addQueue(AmqpQueue queue);
 
     /**
+     * Get a queue {@link AmqpQueue} with queue name.
+     * @param queueName AMQP queue name.
+     * @return AMQP queue.
+     */
+    AmqpQueue getQueue(String queueName);
+
+    /**
      * Remove a queue {@link AmqpQueue} from the exchange.
      * @param queue AMQP queue.
      */


### PR DESCRIPTION
Master Issue: #596

### Motivation

The queue corresponding to the default Exchange cannot consume messages when the broker restarts or the namespace migrates to another broker.

### Modifications

Unload or broker restart can still consume normally.

### Verifying this change

`Set<AmqpQueue> queues` in Exchange cannot be persisted after the broker has restarted. Queue validation was added to the BasicPublish interface.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)
