### PR TITLE
feat: add basic authentication support

### DIFF
--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/authentication/AuthenticationProviderBasic.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/authentication/AuthenticationProviderBasic.java
@@ -1,0 +1,162 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.amqp.authentication;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.naming.AuthenticationException;
+import lombok.Cleanup;
+import lombok.SneakyThrows;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.codec.digest.Crypt;
+import org.apache.commons.codec.digest.Md5Crypt;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.pulsar.broker.ServiceConfiguration;
+import org.apache.pulsar.broker.authentication.AuthenticationDataSource;
+import org.apache.pulsar.broker.authentication.AuthenticationProvider;
+import org.apache.pulsar.broker.authentication.metrics.AuthenticationMetrics;
+import org.apache.pulsar.client.api.url.URL;
+
+public class AuthenticationProviderBasic implements AuthenticationProvider {
+    private static final String HTTP_HEADER_NAME = "Authorization";
+    private Map<String, String> users;
+
+    @SneakyThrows
+    @Override
+    public void initialize(ServiceConfiguration config) {
+        String basicAuthConf = (String) config.getProperty("basicAuthConf");
+
+        byte[] data;
+        boolean isFile = basicAuthConf.startsWith("file:");
+        if (isFile) {
+            data = IOUtils.toByteArray(URL.createURL(basicAuthConf));
+        } else if (Base64.isBase64(basicAuthConf)) {
+            data = Base64.decodeBase64(basicAuthConf);
+        } else {
+            throw new IllegalArgumentException("Not support format");
+        }
+
+        @Cleanup BufferedReader reader = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(data),
+                StandardCharsets.UTF_8));
+        users = new HashMap<>();
+        for (String line : reader.lines().toArray(s -> new String[s])) {
+            List<String> splitLine = Arrays.asList(line.split(":"));
+            if (splitLine.size() != 2) {
+                throw new IOException("The format of the password auth conf file is invalid");
+            }
+            users.put(splitLine.get(0), splitLine.get(1));
+        }
+    }
+
+    @Override
+    public String getAuthMethodName() {
+        return "basic";
+    }
+
+    @Override
+    public String authenticate(AuthenticationDataSource authData) throws AuthenticationException {
+        AuthParams authParams = new AuthParams(authData);
+        String userId = authParams.getUserId();
+        String password = authParams.getPassword();
+        String msg = "Unknown user or invalid password";
+
+        try {
+            if (users.get(userId) == null) {
+                throw new AuthenticationException(msg);
+            }
+
+            String encryptedPassword = users.get(userId);
+
+            // For md5 algorithm
+            if ((users.get(userId).startsWith("$apr1"))) {
+                List<String> splitEncryptedPassword = Arrays.asList(encryptedPassword.split("\\$"));
+                if (splitEncryptedPassword.size() != 4 || !encryptedPassword
+                        .equals(Md5Crypt.apr1Crypt(password.getBytes(StandardCharsets.UTF_8),
+                                splitEncryptedPassword.get(2)))) {
+                    throw new AuthenticationException(msg);
+                }
+                // For crypt algorithm
+            } else if (!encryptedPassword.equals(Crypt.crypt(password.getBytes(StandardCharsets.UTF_8),
+                    encryptedPassword.substring(0, 2)))) {
+                throw new AuthenticationException(msg);
+            }
+        } catch (AuthenticationException exception) {
+            AuthenticationMetrics.authenticateFailure(getClass().getSimpleName(), getAuthMethodName(),
+                    exception.getMessage());
+            throw exception;
+        }
+        AuthenticationMetrics.authenticateSuccess(getClass().getSimpleName(), getAuthMethodName());
+        return userId;
+    }
+
+    @Override
+    public void close() throws IOException {
+        // noop
+    }
+
+    private static class AuthParams {
+        private final String userId;
+        private final String password;
+
+        public AuthParams(AuthenticationDataSource authData) throws AuthenticationException {
+            String authParams;
+            if (authData.hasDataFromCommand()) {
+                authParams = authData.getCommandData();
+            } else if (authData.hasDataFromHttp()) {
+                String rawAuthToken = authData.getHttpHeader(HTTP_HEADER_NAME);
+                // parsing and validation
+                if (StringUtils.isBlank(rawAuthToken) || !rawAuthToken.toUpperCase().startsWith("BASIC ")) {
+                    throw new AuthenticationException("Authentication token has to be started with \"Basic \"");
+                }
+                String[] splitRawAuthToken = rawAuthToken.split(" ");
+                if (splitRawAuthToken.length != 2) {
+                    throw new AuthenticationException("Base64 encoded token is not found");
+                }
+
+                try {
+                    authParams = new String(java.util.Base64.getDecoder().decode(splitRawAuthToken[1]),
+                            StandardCharsets.UTF_8);
+                } catch (Exception e) {
+                    throw new AuthenticationException("Base64 decoding is failure: " + e.getMessage());
+                }
+            } else {
+                throw new AuthenticationException("Authentication data source does not have data");
+            }
+
+            String[] parsedAuthParams = authParams.split(":");
+            if (parsedAuthParams.length != 2) {
+                throw new AuthenticationException("Base64 decoded params are invalid");
+            }
+
+            userId = parsedAuthParams[0];
+            password = parsedAuthParams[1];
+        }
+
+        public String getUserId() {
+            return userId;
+        }
+
+        public String getPassword() {
+            return password;
+        }
+    }
+}

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/authentication/package-info.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/authentication/package-info.java
@@ -1,0 +1,15 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.streamnative.pulsar.handlers.amqp.authentication;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/AmqpTokenAuthenticationTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/AmqpTokenAuthenticationTestBase.java
@@ -15,12 +15,15 @@ package io.streamnative.pulsar.handlers.amqp;
 
 import com.google.common.collect.Sets;
 import io.jsonwebtoken.SignatureAlgorithm;
+import io.streamnative.pulsar.handlers.amqp.authentication.AuthenticationProviderBasic;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
 import javax.crypto.SecretKey;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.codec.binary.Base64;
 import org.apache.pulsar.broker.authentication.AuthenticationProviderToken;
 import org.apache.pulsar.broker.authentication.utils.AuthTokenUtils;
 import org.apache.pulsar.client.impl.auth.AuthenticationToken;
@@ -44,10 +47,15 @@ public class AmqpTokenAuthenticationTestBase extends AmqpProtocolHandlerTestBase
     @Override
     public void setup() throws Exception {
         conf.setAuthenticationEnabled(true);
-        conf.setAuthenticationProviders(Sets.newHashSet(AuthenticationProviderToken.class.getName()));
-
+        conf.setAuthenticationProviders(Sets.newHashSet(
+                AuthenticationProviderToken.class.getName(),
+                AuthenticationProviderBasic.class.getName()
+        ));
         Properties properties = new Properties();
         properties.setProperty("tokenSecretKey", AuthTokenUtils.encodeKeyBase64(secretKey));
+        String basicAuthConf = Base64.encodeBase64String(("superUser:mQQQIsyvvKRtU\n"
+                + "superUser2:$apr1$foobarmq$kuSZlLgOITksCkRgl57ie/\n").getBytes(StandardCharsets.UTF_8));
+        properties.setProperty("basicAuthConf", basicAuthConf);
         conf.setProperties(properties);
 
         conf.setBrokerClientAuthenticationPlugin(AuthenticationToken.class.getName());

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/authentication/PlainAuthenticationTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/authentication/PlainAuthenticationTest.java
@@ -1,0 +1,84 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.amqp.rabbitmq.authentication;
+
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Connection;
+import com.rabbitmq.client.ConnectionFactory;
+import com.rabbitmq.client.PossibleAuthenticationFailureException;
+import io.streamnative.pulsar.handlers.amqp.AmqpTokenAuthenticationTestBase;
+import java.io.IOException;
+import java.util.concurrent.TimeoutException;
+import lombok.Cleanup;
+import org.testng.annotations.Test;
+
+/**
+ * PlainAuthenticationTest tests the plain authentication.
+ */
+public class PlainAuthenticationTest extends AmqpTokenAuthenticationTestBase {
+    private void testConnect(int port) throws Exception {
+        ConnectionFactory connectionFactory = new ConnectionFactory();
+        connectionFactory.setHost("localhost");
+        connectionFactory.setPort(port);
+        connectionFactory.setVirtualHost("vhost1");
+        connectionFactory.setUsername("superUser2");
+        connectionFactory.setPassword("superpassword");
+        @Cleanup
+        Connection connection = connectionFactory.newConnection();
+        @Cleanup
+        Channel ignored = connection.createChannel();
+    }
+
+    @Test
+    public void testConnectToBroker() throws Exception {
+        testConnect(getAmqpBrokerPortList().get(0));
+    }
+
+    @Test
+    public void testConnectToProxy() throws Exception {
+        testConnect(getAopProxyPortList().get(0));
+    }
+
+    private void testConnectWithInvalidToken(int port, boolean isProxy) throws IOException, TimeoutException {
+        ConnectionFactory connectionFactory = new ConnectionFactory();
+        connectionFactory.setHost("localhost");
+        connectionFactory.setPort(port);
+        connectionFactory.setVirtualHost("vhost1");
+        connectionFactory.setUsername("superUser2");
+        connectionFactory.setPassword("invalidpassword");
+
+        Exception exception;
+        if (isProxy) {
+            exception = expectThrows(IOException.class,
+                    connectionFactory::newConnection);
+        } else {
+            exception = expectThrows(PossibleAuthenticationFailureException.class,
+                    connectionFactory::newConnection);
+        }
+        assertTrue(exception.getCause().getMessage().contains("Authentication failed"));
+    }
+
+    @Test
+    public void testConnectToBrokerWithInvalidToken() throws IOException, TimeoutException {
+        testConnectWithInvalidToken(getAmqpBrokerPortList().get(0), false);
+    }
+
+    @Test
+    public void testConnectToProxyWithInvalidToken() throws IOException, TimeoutException {
+        testConnectWithInvalidToken(getAopProxyPortList().get(0), true);
+    }
+}


### PR DESCRIPTION
Signed-off-by: Zixuan Liu <nodeces@gmail.com>

### Motivation

Add basic authentication support, we depend on https://httpd.apache.org/docs/2.4/programs/htpasswd.html to generate the basic authentication data source.

### Modifications

- Add `io.streamnative.pulsar.handlers.amqp.authentication.AuthenticationProviderBasic` for provide the basic authentication
   - This provider reads the `basicAuthConf` from `org.apache.pulsar.broker.ServiceConfiguration` as basic data source, supports both format file and Base64 data, so like: `basicAuthConf=file:///user/dev/.aoppassword` or `basicAuthConf=c3VwZXJVc2VyOm1RUVFJc3l2dktSdFUKc3VwZXJVc2VyMjokYXByMSRmb29iYXJtcSRrdVNabExnT0lUa3NDa1JnbDU3aWUvCg==`
      - When using the file format, we can using the password file generated by htpasswd
      - When using the Base64 data, we need to encode the the body from password file generated by htpasswd

### Documentation

- [x] `doc-required` 