### PR TITLE
[fix] release the buf when proxyConnection init

### DIFF
--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/proxy/ProxyConnection.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/proxy/ProxyConnection.java
@@ -137,6 +137,8 @@ public class ProxyConnection extends ChannelInboundHandlerAdapter implements
                 } catch (Throwable e) {
                     log.error("error while handle command:", e);
                     close();
+                } finally {
+                    buffer.release();
                 }
 
                 break;

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/proxy/ProxyHandler.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/proxy/ProxyHandler.java
@@ -144,7 +144,10 @@ public class ProxyHandler {
                     } catch (Throwable e) {
                         log.error("error while handle command:", e);
                         close();
+                    } finally {
+                      buffer.release();
                     }
+
                     break;
                 case Connected:
                     clientChannel.writeAndFlush(msg);


### PR DESCRIPTION
Fixes #214 

### Motivation

release the buffer when proxyConnection init

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)
