### PR TITLE
[fix]autoDelete exchange test

### DIFF
--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpChannel.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpChannel.java
@@ -252,7 +252,8 @@ public class AmqpChannel implements ServerChannelMethodProcessor {
                             + "exclusive:{}, autoDelete:{}, nowait:{}, arguments:{} ]",
                     channelId, queue, passive, durable, exclusive, autoDelete, nowait, arguments);
         }
-        queueService.queueDeclare(connection.getNamespaceName(), queue.toString(), passive, durable, exclusive,
+        queueService.queueDeclare(connection.getNamespaceName(), AMQShortString.toString(queue),
+                passive, durable, exclusive,
                 autoDelete, nowait, arguments, connection.getConnectionId()).thenAccept(amqpQueue -> {
             setDefaultQueue(amqpQueue);
             MethodRegistry methodRegistry = connection.getMethodRegistry();
@@ -345,7 +346,7 @@ public class AmqpChannel implements ServerChannelMethodProcessor {
                     exchange, bindingKey, arguments);
         }
         queueService.queueUnbind(connection.getNamespaceName(), queue.toString(), exchange.toString(),
-                bindingKey.toString(), arguments, connection.getConnectionId()).thenAccept(__ -> {
+                AMQShortString.toString(bindingKey), arguments, connection.getConnectionId()).thenAccept(__ -> {
             AMQMethodBody responseBody = connection.getMethodRegistry().createQueueUnbindOkBody();
             connection.writeFrame(responseBody.generateFrame(channelId));
         }).exceptionally(t -> {

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/UnbindAutoDeleteExchange.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/functional/UnbindAutoDeleteExchange.java
@@ -19,14 +19,15 @@ import static org.junit.Assert.fail;
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.test.BrokerTestCase;
 import java.io.IOException;
+import org.testng.annotations.Test;
 
 /**
  * Test that unbinding from an auto-delete exchange causes the exchange to go away.
  *
  */
 public class UnbindAutoDeleteExchange extends BrokerTestCase {
-    ////@Test
-    public void unbind() throws IOException, InterruptedException {
+    @Test
+    public void unbind() throws IOException{
         String exchange = "myexchange";
         channel.exchangeDeclare(exchange, "fanout", false, true, null);
         String queue = channel.queueDeclare().getQueue();


### PR DESCRIPTION
Master Issue: #63

### Motivation

support autoDelete exchange and autoDelete queue
autoDelete exchange:  exchange is deleted when last queue is unbound from it
autoDelete queue:  queue that has had at least one consumer is deleted when last consumer unsubscribes
more detail: https://www.rabbitmq.com/tutorials/amqp-concepts.html

### Modifications

*Describe the modifications you've done.*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation
  
- [x] `no-need-doc` 
  

  

