### PR TITLE
Async route exchange messages

### DIFF
--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpBrokerService.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpBrokerService.java
@@ -44,7 +44,6 @@ public class AmqpBrokerService {
     public AmqpBrokerService(PulsarService pulsarService, AmqpServiceConfiguration config) {
         this.pulsarService = pulsarService;
         this.amqpTopicManager = new AmqpTopicManager(pulsarService);
-        initRouteExecutor(config);
         this.exchangeContainer = new ExchangeContainer(amqpTopicManager, pulsarService, initRouteExecutor(config),
                 config.getAmqpExchangeRouteQueueSize());
         this.queueContainer = new QueueContainer(amqpTopicManager, pulsarService, exchangeContainer);
@@ -57,7 +56,6 @@ public class AmqpBrokerService {
                              ConnectionContainer connectionContainer) {
         this.pulsarService = pulsarService;
         this.amqpTopicManager = new AmqpTopicManager(pulsarService);
-        initRouteExecutor(config);
         this.exchangeContainer = new ExchangeContainer(amqpTopicManager, pulsarService, initRouteExecutor(config),
                 config.getAmqpExchangeRouteQueueSize());
         this.queueContainer = new QueueContainer(amqpTopicManager, pulsarService, exchangeContainer);

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpBrokerService.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpBrokerService.java
@@ -52,18 +52,6 @@ public class AmqpBrokerService {
         this.connectionContainer = new ConnectionContainer(pulsarService, exchangeContainer, queueContainer);
     }
 
-    public AmqpBrokerService(PulsarService pulsarService, AmqpServiceConfiguration config,
-                             ConnectionContainer connectionContainer) {
-        this.pulsarService = pulsarService;
-        this.amqpTopicManager = new AmqpTopicManager(pulsarService);
-        this.exchangeContainer = new ExchangeContainer(amqpTopicManager, pulsarService, initRouteExecutor(config),
-                config.getAmqpExchangeRouteQueueSize());
-        this.queueContainer = new QueueContainer(amqpTopicManager, pulsarService, exchangeContainer);
-        this.exchangeService = new ExchangeServiceImpl(exchangeContainer);
-        this.queueService = new QueueServiceImpl(exchangeContainer, queueContainer);
-        this.connectionContainer = connectionContainer;
-    }
-
     private Executor initRouteExecutor(AmqpServiceConfiguration config) {
         return new ThreadPoolExecutor(config.getAmqpExchangeRouteExecutorThreads(),
                 config.getAmqpExchangeRouteExecutorThreads(), 30, TimeUnit.SECONDS,

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpBrokerService.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpBrokerService.java
@@ -14,10 +14,9 @@
 
 package io.streamnative.pulsar.handlers.amqp;
 
-import java.util.concurrent.ArrayBlockingQueue;
+import io.netty.util.concurrent.DefaultThreadFactory;
 import java.util.concurrent.Executor;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.Executors;
 import lombok.Getter;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.authentication.AuthenticationService;
@@ -53,9 +52,8 @@ public class AmqpBrokerService {
     }
 
     private Executor initRouteExecutor(AmqpServiceConfiguration config) {
-        return new ThreadPoolExecutor(config.getAmqpExchangeRouteExecutorThreads(),
-                config.getAmqpExchangeRouteExecutorThreads(), 30, TimeUnit.SECONDS,
-                new ArrayBlockingQueue<>(1000));
+        return Executors.newFixedThreadPool(config.getAmqpExchangeRouteExecutorThreads(),
+                new DefaultThreadFactory("exchange-route"));
     }
 
     public boolean isAuthenticationEnabled() {

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpExchangeReplicator.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpExchangeReplicator.java
@@ -65,8 +65,7 @@ public abstract class AmqpExchangeReplicator implements AsyncCallbacks.ReadEntri
     }
 
     private static final int defaultReadMaxSizeBytes = 5 * 1024 * 1024;
-    private int routeQueueSize =
-            Integer.parseInt(System.getProperty("aop.replicatorQueueSize", "250"));
+    private int routeQueueSize = 200;
     private volatile int pendingQueueSize = 0;
     private static final AtomicIntegerFieldUpdater<AmqpExchangeReplicator> PENDING_SIZE_UPDATER =
             AtomicIntegerFieldUpdater.newUpdater(AmqpExchangeReplicator.class, "pendingQueueSize");

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpExchangeReplicator.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpExchangeReplicator.java
@@ -15,9 +15,12 @@ package io.streamnative.pulsar.handlers.amqp;
 
 import static org.apache.pulsar.broker.service.persistent.PersistentTopic.MESSAGE_RATE_BACKOFF_MS;
 
+import io.netty.buffer.ByteBuf;
 import io.streamnative.pulsar.handlers.amqp.impl.PersistentExchange;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
@@ -27,6 +30,9 @@ import org.apache.bookkeeper.mledger.AsyncCallbacks;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
+import org.apache.bookkeeper.mledger.Position;
+import org.apache.bookkeeper.mledger.impl.PositionImpl;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.client.impl.Backoff;
 import org.apache.pulsar.common.api.proto.CommandSubscribe;
@@ -58,8 +64,9 @@ public abstract class AmqpExchangeReplicator implements AsyncCallbacks.ReadEntri
         Stopped, Starting, Started, Stopping
     }
 
-    private static final int defaultReadMaxSizeBytes = 4 * 1024 * 1024;
-    private static final int replicatorQueueSize = 1000;
+    private static final int defaultReadMaxSizeBytes = 5 * 1024 * 1024;
+    private int routeQueueSize =
+            Integer.parseInt(System.getProperty("aop.replicatorQueueSize", "250"));
     private volatile int pendingQueueSize = 0;
     private static final AtomicIntegerFieldUpdater<AmqpExchangeReplicator> PENDING_SIZE_UPDATER =
             AtomicIntegerFieldUpdater.newUpdater(AmqpExchangeReplicator.class, "pendingQueueSize");
@@ -74,12 +81,26 @@ public abstract class AmqpExchangeReplicator implements AsyncCallbacks.ReadEntri
     private final Backoff readFailureBackoff = new Backoff(
             1, TimeUnit.SECONDS, 1, TimeUnit.MINUTES, 0, TimeUnit.MILLISECONDS);
 
-    protected AmqpExchangeReplicator(PersistentExchange persistentExchange) {
+    private final Executor routeExecutor;
+
+    protected AmqpExchangeReplicator(PersistentExchange persistentExchange, Executor routeExecutor,
+                                     int routeQueueSize) {
         this.persistentExchange = persistentExchange;
         this.topic = (PersistentTopic) persistentExchange.getTopic();
         this.scheduledExecutorService = topic.getBrokerService().executor();
+        this.initMaxRouteQueueSize(routeQueueSize);
+        this.routeExecutor = routeExecutor;
         STATE_UPDATER.set(this, AmqpExchangeReplicator.State.Stopped);
         this.name = "[AMQP Replicator for " + topic.getName() + " ]";
+    }
+
+    private void initMaxRouteQueueSize(int maxRouteQueueSize) {
+        if (System.getProperty("aop.replicatorQueueSize") != null) {
+            this.routeQueueSize = Integer.parseInt(
+                    System.getProperty("aop.replicatorQueueSize", "" + maxRouteQueueSize));
+            return;
+        }
+        this.routeQueueSize = maxRouteQueueSize;
     }
 
     public void startReplicate() {
@@ -103,8 +124,6 @@ public abstract class AmqpExchangeReplicator implements AsyncCallbacks.ReadEntri
             }
             return;
         }
-
-        log.info("{} Replicator is starting.", name);
 
         topic.getManagedLedger().asyncOpenCursor(cursorNamePre + persistentExchange.getName(),
                 CommandSubscribe.InitialPosition.Earliest,
@@ -146,7 +165,7 @@ public abstract class AmqpExchangeReplicator implements AsyncCallbacks.ReadEntri
         cursor.setActive();
 
         STATE_UPDATER.set(this, State.Started);
-        log.info("{} Replicator is started.", name);
+        log.info("{} Replicator is started, routeQueueSize: {}.", name, this.routeQueueSize);
 
         readMoreEntries();
     }
@@ -175,7 +194,7 @@ public abstract class AmqpExchangeReplicator implements AsyncCallbacks.ReadEntri
     }
 
     private int getAvailablePermits() {
-        int availablePermits = replicatorQueueSize - PENDING_SIZE_UPDATER.get(this);
+        int availablePermits = routeQueueSize - PENDING_SIZE_UPDATER.get(this);
         if (availablePermits <= 0) {
             if (log.isDebugEnabled()) {
                 log.debug("{} Replicator queue is full, availablePermits: {}, pause route.",
@@ -191,40 +210,47 @@ public abstract class AmqpExchangeReplicator implements AsyncCallbacks.ReadEntri
         if (log.isDebugEnabled()) {
             log.debug("{} Read entries complete. Entries size: {}", name, list.size());
         }
-        for (Entry entry : list) {
-            try {
-                PENDING_SIZE_UPDATER.incrementAndGet(this);
-                CompletableFuture<Void> completableFuture = readProcess(entry);
-                completableFuture.whenComplete((ignored, exception) -> {
-                    if (exception != null) {
-                        log.error("{} Error producing messages", name, exception);
-                        AmqpExchangeReplicator.this.cursor.rewind();
-                    } else {
-                        if (log.isDebugEnabled()) {
-                            log.debug("{} Route message successfully.", name);
-                        }
-                        AmqpExchangeReplicator.this.cursor
-                                .asyncDelete(entry.getPosition(), this, entry.getPosition());
-                    }
-                    entry.release();
-
-                    int pending = PENDING_SIZE_UPDATER.decrementAndGet(this);
-                    if (pending == 0 && HAVE_PENDING_READ_UPDATER.get(this) == FALSE) {
-                        AmqpExchangeReplicator.this.readMoreEntries();
-                    }
-                });
-            } catch (Exception e) {
-                PENDING_SIZE_UPDATER.decrementAndGet(this);
-                log.warn("Route message failed.", e);
-            }
-        }
-
         HAVE_PENDING_READ_UPDATER.set(this, FALSE);
-
-        readMoreEntries();
+        if (list == null || list.isEmpty()) {
+            long delay = readFailureBackoff.next();
+            log.warn("{} The read entry list is empty, will retry in {} ms. ReadPosition: {}, LAC: {}.",
+                    name, delay, cursor.getReadPosition(), topic.getManagedLedger().getLastConfirmedEntry());
+            scheduledExecutorService.schedule(this::readMoreEntries, delay, TimeUnit.MILLISECONDS);
+            return;
+        }
+        readFailureBackoff.reduceToHalf();
+        List<Pair<PositionImpl, ByteBuf>> bufList = new ArrayList<>(list.size());
+        for (Entry entry : list) {
+            bufList.add(
+                    Pair.of(PositionImpl.get(entry.getLedgerId(), entry.getEntryId()), entry.getDataBuffer()));
+        }
+        routeExecutor.execute(() -> this.readComplete(bufList));
     }
 
-    public abstract CompletableFuture<Void> readProcess(Entry entry);
+    private void readComplete(List<Pair<PositionImpl, ByteBuf>> list) {
+        for (Pair<PositionImpl, ByteBuf> entry : list) {
+            PENDING_SIZE_UPDATER.incrementAndGet(this);
+            readProcess(entry.getRight(), entry.getLeft()).whenCompleteAsync((ignored, exception) -> {
+                if (exception != null) {
+                    log.error("{} Error producing messages", name, exception);
+                    this.cursor.rewind();
+                } else {
+                    if (log.isDebugEnabled()) {
+                        log.debug("{} Route message successfully.", name);
+                    }
+                    AmqpExchangeReplicator.this.cursor
+                            .asyncDelete(entry.getLeft(), this, entry.getLeft());
+                }
+                if (PENDING_SIZE_UPDATER.decrementAndGet(this) < routeQueueSize * 0.5
+                        && HAVE_PENDING_READ_UPDATER.get(this) == FALSE) {
+                    this.readMoreEntries();
+                }
+            }, routeExecutor);
+            entry.getRight().release();
+        }
+    }
+
+    public abstract CompletableFuture<Void> readProcess(ByteBuf data, Position position);
 
     @Override
     public void readEntriesFailed(ManagedLedgerException exception, Object o) {

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpProtocolHandler.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpProtocolHandler.java
@@ -93,7 +93,7 @@ public class AmqpProtocolHandler implements ProtocolHandler {
     @Override
     public void start(BrokerService service) {
         brokerService = service;
-        amqpBrokerService = new AmqpBrokerService(service.getPulsar());
+        amqpBrokerService = new AmqpBrokerService(service.getPulsar(), amqpConfig);
         if (amqpConfig.isAmqpProxyEnable()) {
             ProxyConfiguration proxyConfig = new ProxyConfiguration();
             proxyConfig.setAmqpTenant(amqpConfig.getAmqpTenant());

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpServiceConfiguration.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpServiceConfiguration.java
@@ -112,4 +112,19 @@ public class AmqpServiceConfiguration extends ServiceConfiguration {
     )
     private int amqpExplicitFlushAfterFlushes = 1000;
 
+
+    @FieldContext(
+            category = CATEGORY_AMQP,
+            required = false,
+            doc = "Exchange route queue size."
+    )
+    private int amqpExchangeRouteQueueSize = 250;
+
+    @FieldContext(
+            category = CATEGORY_AMQP,
+            required = false,
+            doc = "Threads count for route exchange messages."
+    )
+    private int amqpExchangeRouteExecutorThreads = Runtime.getRuntime().availableProcessors();
+
 }

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpServiceConfiguration.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpServiceConfiguration.java
@@ -105,20 +105,18 @@ public class AmqpServiceConfiguration extends ServiceConfiguration {
     )
     private int amqpAdminPort = 15673;
 
-
     @FieldContext(
             category = CATEGORY_AMQP,
             required = false
     )
     private int amqpExplicitFlushAfterFlushes = 1000;
 
-
     @FieldContext(
             category = CATEGORY_AMQP,
             required = false,
             doc = "Exchange route queue size."
     )
-    private int amqpExchangeRouteQueueSize = 250;
+    private int amqpExchangeRouteQueueSize = 200;
 
     @FieldContext(
             category = CATEGORY_AMQP,

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/ExchangeContainer.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/ExchangeContainer.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -46,10 +47,15 @@ public class ExchangeContainer {
 
     private AmqpTopicManager amqpTopicManager;
     private PulsarService pulsarService;
+    private final Executor routeExecutor;
+    private final int routeQueueSize;
 
-    protected ExchangeContainer(AmqpTopicManager amqpTopicManager, PulsarService pulsarService) {
+    protected ExchangeContainer(AmqpTopicManager amqpTopicManager, PulsarService pulsarService,
+                                Executor routeExecutor, int routeQueueSize) {
         this.amqpTopicManager = amqpTopicManager;
         this.pulsarService = pulsarService;
+        this.routeExecutor = routeExecutor;
+        this.routeQueueSize = routeQueueSize;
     }
 
     @Getter
@@ -158,7 +164,7 @@ public class ExchangeContainer {
                             amqpExchange = new PersistentExchange(exchangeName,
                                     AmqpExchange.Type.value(currentType),
                                     persistentTopic, currentDurable, currentAutoDelete, currentInternal,
-                                    currentArguments);
+                                    currentArguments, routeExecutor, routeQueueSize);
                         } catch (Exception e) {
                             log.error("Failed to init exchange {} in vhost {}.",
                                     exchangeName, namespaceName.getLocalName(), e);

--- a/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/AmqpProtocolTestBase.java
+++ b/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/AmqpProtocolTestBase.java
@@ -99,8 +99,7 @@ public abstract class AmqpProtocolTestBase {
     public void setup() throws Exception {
         mockPulsarService();
         mockBrokerService();
-        ConnectionContainer connectionContainer = mock(ConnectionContainer.class);
-        amqpBrokerService = new AmqpBrokerService(pulsarService, new AmqpServiceConfiguration(), connectionContainer);
+        amqpBrokerService = new AmqpBrokerService(pulsarService, new AmqpServiceConfiguration());
         amqpTopicManager = amqpBrokerService.getAmqpTopicManager();
 
         // 1.Init AMQP connection for connection methods and channel methods tests.
@@ -159,6 +158,7 @@ public abstract class AmqpProtocolTestBase {
         PulsarResources pulsarResources = mock(PulsarResources.class);
         when(pulsarResources.getNamespaceResources()).thenReturn(namespaceResources);
         when(pulsarService.getPulsarResources()).thenReturn(pulsarResources);
+        when(pulsarService.getNamespaceService()).thenReturn(mock(NamespaceService.class));
     }
 
     private void mockBrokerService() {

--- a/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/AmqpProtocolTestBase.java
+++ b/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/AmqpProtocolTestBase.java
@@ -100,7 +100,7 @@ public abstract class AmqpProtocolTestBase {
         mockPulsarService();
         mockBrokerService();
         ConnectionContainer connectionContainer = mock(ConnectionContainer.class);
-        amqpBrokerService = new AmqpBrokerService(pulsarService, connectionContainer);
+        amqpBrokerService = new AmqpBrokerService(pulsarService, new AmqpServiceConfiguration(), connectionContainer);
         amqpTopicManager = amqpBrokerService.getAmqpTopicManager();
 
         // 1.Init AMQP connection for connection methods and channel methods tests.

--- a/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/AmqpProtocolTestBase.java
+++ b/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/AmqpProtocolTestBase.java
@@ -29,7 +29,6 @@ import io.streamnative.pulsar.handlers.amqp.AmqpConnection;
 import io.streamnative.pulsar.handlers.amqp.AmqpPulsarServerCnx;
 import io.streamnative.pulsar.handlers.amqp.AmqpServiceConfiguration;
 import io.streamnative.pulsar.handlers.amqp.AmqpTopicManager;
-import io.streamnative.pulsar.handlers.amqp.ConnectionContainer;
 import io.streamnative.pulsar.handlers.amqp.test.mock.MockDispatcher;
 import java.net.SocketAddress;
 import java.util.Map;

--- a/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/TopicNameTest.java
+++ b/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/TopicNameTest.java
@@ -21,6 +21,7 @@ import io.netty.channel.EventLoopGroup;
 import io.streamnative.pulsar.handlers.amqp.AbstractAmqpExchange;
 import io.streamnative.pulsar.handlers.amqp.impl.PersistentExchange;
 import io.streamnative.pulsar.handlers.amqp.impl.PersistentQueue;
+import java.util.concurrent.Executors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.impl.ManagedCursorContainer;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
@@ -50,7 +51,8 @@ public class TopicNameTest {
         Mockito.when(managedLedger.getCursors()).thenReturn(new ManagedCursorContainer());
         try {
             new PersistentExchange(
-                    exchangeName, exchangeType, exchangeTopic1, true, false, false, null);
+                    exchangeName, exchangeType, exchangeTopic1, true, false, false, null,
+                    Executors.newSingleThreadExecutor(), 200);
         } catch (IllegalArgumentException e) {
             fail("Failed to new PersistentExchange. errorMsg: " + e.getMessage());
         }
@@ -60,7 +62,8 @@ public class TopicNameTest {
         Mockito.when(exchangeTopic2.getManagedLedger()).thenReturn(managedLedger);
         try {
             new PersistentExchange(
-                    exchangeName, exchangeType, exchangeTopic2, true, false, false, null);
+                    exchangeName, exchangeType, exchangeTopic2, true, false, false, null,
+                    Executors.newSingleThreadExecutor(), 200);
         } catch (IllegalArgumentException e) {
             assertNotNull(e);
             log.info("This is expected behavior.");


### PR DESCRIPTION
### Motivation

Currently, the exchange route process uses the same threads with bk read complete callback.

### Modifications

Use a new executor to route exchange messages.
Add two configurations `amqpExchangeRouteQueueSize` and `amqpExchangeRouteExecutorThreads` to control exchange message routing.

### Verifying this change

This change is already covered by existing tests.

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)
