### PR TITLE
Optimize direct and fanout exchange route logic

### DIFF
--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AbstractAmqpExchange.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AbstractAmqpExchange.java
@@ -17,6 +17,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Base class of AMQP exchange.
@@ -30,6 +31,8 @@ public abstract class AbstractAmqpExchange implements AmqpExchange {
     protected boolean autoDelete;
     protected boolean internal;
     protected Map<String, Object> arguments;
+    protected Map<String, Set<AmqpQueue>> bindingKeyQueueMap;
+
     public static final String DEFAULT_EXCHANGE_DURABLE = "aop.direct.durable";
 
     protected AbstractAmqpExchange(String exchangeName, AmqpExchange.Type exchangeType,
@@ -42,6 +45,9 @@ public abstract class AbstractAmqpExchange implements AmqpExchange {
         this.autoDelete = autoDelete;
         this.internal = internal;
         this.arguments = arguments;
+        if (this.exchangeType == Type.Direct) {
+            bindingKeyQueueMap = new ConcurrentHashMap<>();
+        }
     }
 
     @Override

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/impl/PersistentExchange.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/impl/PersistentExchange.java
@@ -225,7 +225,7 @@ public class PersistentExchange extends AbstractAmqpExchange {
     }
 
     @Override
-    public CompletableFuture<Void> addQueue(AmqpQueue queue) {
+    public synchronized CompletableFuture<Void> addQueue(AmqpQueue queue) {
         queues.add(queue);
         if (exchangeType == Type.Direct) {
             for (String bindingKey : queue.getRouter(exchangeName).getBindingKey()) {
@@ -246,11 +246,14 @@ public class PersistentExchange extends AbstractAmqpExchange {
     }
 
     @Override
-    public void removeQueue(AmqpQueue queue) {
+    public synchronized void removeQueue(AmqpQueue queue) {
         queues.remove(queue);
-        if (bindingKeyQueueMap != null) {
-            for (Set<AmqpQueue> queueSet : bindingKeyQueueMap.values()) {
-                queueSet.remove(queue);
+        if (exchangeType == Type.Direct) {
+            for (Map.Entry<String, Set<AmqpQueue>> entry : bindingKeyQueueMap.entrySet()) {
+                entry.getValue().remove(queue);
+                if (entry.getValue().isEmpty()) {
+                    bindingKeyQueueMap.remove(entry.getKey());
+                }
             }
         }
         updateExchangeProperties();


### PR DESCRIPTION
### Motivation

Currently, each queue getting the corresponding router will cost a lot of resources, optimize direct and fanout exchange gets router logic, and doesn't need to check every queue.

### Modifications

For direct exchange, use a map to record the routing key map to the bound queue list, when routing messages, get the bound queue list with the binding key and route messages to them.
For fanout exchange, write index messages directly.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)
