### PR TITLE
[fix]consume large messages (body size > 10*1024) failed

### DIFF
--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpConnection.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpConnection.java
@@ -735,7 +735,7 @@ public class AmqpConnection extends AmqpCommandDecoder implements ServerMethodPr
     }
 
     public boolean isCompressionSupported() {
-        return true;
+        return false;
     }
 
     public int getMessageCompressionThreshold() {


### PR DESCRIPTION
Fixes #338 


### Motivation

problem: can not consume large messages (body size > 10*1024)
reason: aop connection doesn't support compression but the method of isCompressionSupported return true

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation
  
- [x] `no-need-doc` 
