### PR TITLE
Remove pulsar-zookeeper-utils dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,12 +164,6 @@
     </dependency>
 
     <dependency>
-      <groupId>io.streamnative</groupId>
-      <artifactId>pulsar-zookeeper-utils</artifactId>
-      <version>${pulsar.version}</version>
-    </dependency>
-
-    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>${guava.version}</version>


### PR DESCRIPTION
The dependency pulsar-zookeeper-utils is useless and it was removed from the latest Pulsar, remove it.