### PR TITLE
Add pulsar bom dependency

### DIFF
--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpChannel.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpChannel.java
@@ -270,7 +270,7 @@ public class AmqpChannel implements ServerChannelMethodProcessor {
         }
 
         CompletableFuture<Subscription> subscriptionFuture = topic.createSubscription(
-                defaultSubscription, CommandSubscribe.InitialPosition.Earliest, false);
+                defaultSubscription, CommandSubscribe.InitialPosition.Earliest, false, null);
         subscriptionFuture.thenAccept(subscription -> {
             AmqpConsumer consumer;
             try {
@@ -390,7 +390,7 @@ public class AmqpChannel implements ServerChannelMethodProcessor {
                         try {
                             if (subscription == null) {
                                 subscription = topic.createSubscription(defaultSubscription,
-                                        CommandSubscribe.InitialPosition.Earliest, false).get();
+                                        CommandSubscribe.InitialPosition.Earliest, false, null).get();
                             }
                             consumer = new AmqpPullConsumer(queueContainer, subscription,
                                     CommandSubscribe.SubType.Shared,

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpProtocolHandler.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpProtocolHandler.java
@@ -97,7 +97,7 @@ public class AmqpProtocolHandler implements ProtocolHandler {
             proxyConfig.setAmqpHeartBeat(amqpConfig.getAmqpHeartBeat());
             proxyConfig.setAmqpProxyPort(amqpConfig.getAmqpProxyPort());
 
-            AdvertisedListener internalListener = ServiceConfigurationUtils.getInternalListener(amqpConfig);
+            AdvertisedListener internalListener = ServiceConfigurationUtils.getInternalListener(amqpConfig, "pulsar");
             checkArgument(internalListener.getBrokerServiceUrl() != null,
                     "plaintext must be configured on internal listener");
             proxyConfig.setBrokerServiceURL(internalListener.getBrokerServiceUrl().toString());

--- a/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/AmqpEncodeHandlerTest.java
+++ b/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/AmqpEncodeHandlerTest.java
@@ -14,7 +14,7 @@
 package io.streamnative.pulsar.handlers.amqp.test;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.junit.Assert.assertTrue;
+import static org.testng.Assert.assertTrue;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
@@ -42,10 +42,9 @@ import org.apache.qpid.server.protocol.ProtocolVersion;
 import org.apache.qpid.server.protocol.v0_8.transport.AMQBody;
 import org.apache.qpid.server.protocol.v0_8.transport.ConnectionSecureBody;
 import org.apache.qpid.server.protocol.v0_8.transport.MethodRegistry;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 /**
  * Amqp Encode Handler Tests.
@@ -61,7 +60,7 @@ public class AmqpEncodeHandlerTest {
 
     private AmqpClientChannel clientChannel;
 
-    @Before
+    @BeforeMethod
     public void setup() {
         group = new NioEventLoopGroup();
         clientChannel = new AmqpClientChannel();
@@ -70,7 +69,7 @@ public class AmqpEncodeHandlerTest {
 
     }
 
-    @After
+    @AfterMethod
     public void destroy() {
         group.shutdownGracefully();
     }
@@ -134,7 +133,7 @@ public class AmqpEncodeHandlerTest {
                 try {
                     clientDecoder.decodeBuffer(buffer.nioBuffer());
                     AMQBody response = (AMQBody) clientChannel.poll(1, SECONDS);
-                    Assert.assertTrue(response instanceof ConnectionSecureBody);
+                    assertTrue(response instanceof ConnectionSecureBody);
                     latch.countDown();
                 } catch (Exception e) {
 

--- a/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/AmqpProtocolTestBase.java
+++ b/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/AmqpProtocolTestBase.java
@@ -184,7 +184,7 @@ public abstract class AmqpProtocolTestBase {
         Mockito.when(subscription.getTopic()).thenReturn(persistentTopic);
         subFuture.complete(subscription);
         Mockito.when(persistentTopic.createSubscription(Mockito.anyString(),
-                Mockito.any(), Mockito.anyBoolean())).thenReturn(subFuture);
+                Mockito.any(), Mockito.anyBoolean(), Mockito.any())).thenReturn(subFuture);
         Mockito.when(subscription.getDispatcher()).thenReturn(mock(MockDispatcher.class));
         Mockito.when(persistentTopic.getSubscriptions()).thenReturn(new ConcurrentOpenHashMap<>());
         Mockito.when(persistentTopic.getManagedLedger()).thenReturn(new MockManagedLedger());

--- a/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/AmqpTopicManagerTest.java
+++ b/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/AmqpTopicManagerTest.java
@@ -14,10 +14,11 @@
 
 package io.streamnative.pulsar.handlers.amqp.test;
 
+import static org.testng.Assert.assertFalse;
+
 import io.streamnative.pulsar.handlers.amqp.AmqpTopicManager;
 import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.broker.service.AbstractTopic;
-import org.junit.Assert;
 import org.testng.annotations.Test;
 
 /**
@@ -31,6 +32,6 @@ public class AmqpTopicManagerTest extends AmqpProtocolTestBase {
         AmqpTopicManager amqpTopicManager = new AmqpTopicManager(pulsarService);
         AbstractTopic abstractTopic = (AbstractTopic) amqpTopicManager.getOrCreateTopic(
                 "public/vhost1/test", true);
-        Assert.assertFalse(abstractTopic.isDeleteWhileInactive());
+        assertFalse(abstractTopic.isDeleteWhileInactive());
     }
 }

--- a/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/TopicNameTest.java
+++ b/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/TopicNameTest.java
@@ -14,6 +14,8 @@
 package io.streamnative.pulsar.handlers.amqp.test;
 
 import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.fail;
 
 import io.netty.channel.EventLoopGroup;
 import io.streamnative.pulsar.handlers.amqp.AbstractAmqpExchange;
@@ -24,7 +26,6 @@ import org.apache.bookkeeper.mledger.impl.ManagedCursorContainer;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
-import org.junit.Assert;
 import org.mockito.Mockito;
 import org.testng.annotations.Test;
 
@@ -51,7 +52,7 @@ public class TopicNameTest {
             new PersistentExchange(
                     exchangeName, exchangeType, exchangeTopic1, false);
         } catch (IllegalArgumentException e) {
-            Assert.fail("Failed to new PersistentExchange. errorMsg: " + e.getMessage());
+            fail("Failed to new PersistentExchange. errorMsg: " + e.getMessage());
         }
 
         PersistentTopic exchangeTopic2 = Mockito.mock(PersistentTopic.class);
@@ -61,7 +62,7 @@ public class TopicNameTest {
             new PersistentExchange(
                     exchangeName, exchangeType, exchangeTopic2, false);
         } catch (IllegalArgumentException e) {
-            Assert.assertNotNull(e);
+            assertNotNull(e);
             log.info("This is expected behavior.");
         }
     }
@@ -78,7 +79,7 @@ public class TopicNameTest {
             new PersistentQueue(
                     queueName, queueTopic1, 0, false, false);
         } catch (IllegalArgumentException e) {
-            Assert.fail("Failed to new PersistentExchange. errorMsg: " + e.getMessage());
+            fail("Failed to new PersistentExchange. errorMsg: " + e.getMessage());
         }
 
         PersistentTopic queueTopic2 = Mockito.mock(PersistentTopic.class);
@@ -88,7 +89,7 @@ public class TopicNameTest {
             new PersistentQueue(
                     queueName, queueTopic2, 0, false, false);
         } catch (IllegalArgumentException e) {
-            Assert.assertNotNull(e);
+            assertNotNull(e);
             log.info("This is expected behavior.");
         }
     }

--- a/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/mock/MockManagedLedger.java
+++ b/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/mock/MockManagedLedger.java
@@ -352,12 +352,16 @@ public class MockManagedLedger implements ManagedLedger {
     }
 
     @Override
-    public ManagedCursor openCursor(String name, CommandSubscribe.InitialPosition initialPosition, Map<String, Long> properties, Map<String, String> cursorProperties) throws InterruptedException, ManagedLedgerException {
+    public ManagedCursor openCursor(String name, CommandSubscribe.InitialPosition initialPosition,
+                                    Map<String, Long> properties, Map<String, String> cursorProperties)
+            throws InterruptedException, ManagedLedgerException {
         return null;
     }
 
     @Override
-    public void asyncOpenCursor(String name, CommandSubscribe.InitialPosition initialPosition, Map<String, Long> properties, Map<String, String> cursorProperties, AsyncCallbacks.OpenCursorCallback callback, Object ctx) {
+    public void asyncOpenCursor(String name, CommandSubscribe.InitialPosition initialPosition,
+                                Map<String, Long> properties, Map<String, String> cursorProperties,
+                                AsyncCallbacks.OpenCursorCallback callback, Object ctx) {
 
     }
 

--- a/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/mock/MockManagedLedger.java
+++ b/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/mock/MockManagedLedger.java
@@ -362,7 +362,7 @@ public class MockManagedLedger implements ManagedLedger {
     public void asyncOpenCursor(String name, CommandSubscribe.InitialPosition initialPosition,
                                 Map<String, Long> properties, Map<String, String> cursorProperties,
                                 AsyncCallbacks.OpenCursorCallback callback, Object ctx) {
-
+        // nothing to do
     }
 
 }

--- a/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/mock/MockManagedLedger.java
+++ b/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/mock/MockManagedLedger.java
@@ -78,13 +78,6 @@ public class MockManagedLedger implements ManagedLedger {
     }
 
     @Override
-    public ManagedCursor openCursor(String s, CommandSubscribe.InitialPosition initialPosition,
-                                    Map<String, Long> map)
-            throws InterruptedException, ManagedLedgerException {
-        return null;
-    }
-
-    @Override
     public ManagedCursor newNonDurableCursor(Position position) throws ManagedLedgerException {
         return null;
     }
@@ -119,12 +112,6 @@ public class MockManagedLedger implements ManagedLedger {
     @Override
     public void asyncOpenCursor(String s, CommandSubscribe.InitialPosition initialPosition,
                                 AsyncCallbacks.OpenCursorCallback openCursorCallback, Object o) {
-
-    }
-
-    @Override
-    public void asyncOpenCursor(String s, CommandSubscribe.InitialPosition initialPosition,
-                                Map<String, Long> map, AsyncCallbacks.OpenCursorCallback openCursorCallback, Object o) {
 
     }
 
@@ -362,6 +349,16 @@ public class MockManagedLedger implements ManagedLedger {
     @Override
     public void removeWaitingCursor(ManagedCursor cursor) {
         // nothing to do
+    }
+
+    @Override
+    public ManagedCursor openCursor(String name, CommandSubscribe.InitialPosition initialPosition, Map<String, Long> properties, Map<String, String> cursorProperties) throws InterruptedException, ManagedLedgerException {
+        return null;
+    }
+
+    @Override
+    public void asyncOpenCursor(String name, CommandSubscribe.InitialPosition initialPosition, Map<String, Long> properties, Map<String, String> cursorProperties, AsyncCallbacks.OpenCursorCallback callback, Object ctx) {
+
     }
 
 }

--- a/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/mock/MockSubscription.java
+++ b/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/mock/MockSubscription.java
@@ -172,4 +172,15 @@ public class MockSubscription implements Subscription {
     public CompletableFuture<Void> endTxn(long txnidMostBits, long txnidLeastBits, int txnAction, long lowWaterMark) {
         return null;
     }
+
+    @Override
+    public Map<String, String> getSubscriptionProperties() {
+        return null;
+    }
+
+    @Override
+    public CompletableFuture<Void> updateSubscriptionProperties(Map<String, String> subscriptionProperties) {
+        return null;
+    }
+
 }

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <log4j2.version>2.17.1</log4j2.version>
     <lombok.version>1.18.4</lombok.version>
     <mockito.version>2.22.0</mockito.version>
-    <pulsar.version>2.10.0.0-rc9</pulsar.version>
+    <pulsar.version>2.10.1.4</pulsar.version>
     <slf4j.version>1.7.25</slf4j.version>
     <spotbugs-annotations.version>3.1.8</spotbugs-annotations.version>
     <testcontainers.version>1.12.5</testcontainers.version>
@@ -87,6 +87,13 @@
   <dependencyManagement>
     <dependencies>
       <!-- provided dependencies -->
+      <dependency>
+        <groupId>io.streamnative</groupId>
+        <artifactId>pulsar</artifactId>
+        <version>${pulsar.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-annotations</artifactId>


### PR DESCRIPTION
### Modifications

1. Upgrade Pulsar to `2.10.1.4`.
2. Add pulsar bom dependency.
3. Unify using the TestNG framework.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)
