### PR TITLE
Add exchange admin endpoints

### DIFF
--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpChannel.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpChannel.java
@@ -216,7 +216,8 @@ public class AmqpChannel implements ServerChannelMethodProcessor {
                     String replyText = null;
                     switch (replyCode) {
                         case ExchangeBoundOkBody.EXCHANGE_NOT_FOUND:
-                            replyText = "Exchange '" + exchange + "' not found in vhost " + connection.getNamespaceName();
+                            replyText = "Exchange '" + exchange + "' not found in vhost "
+                                    + connection.getNamespaceName();
                             break;
                         case ExchangeBoundOkBody.QUEUE_NOT_FOUND:
                             replyText = "Queue '" + queueName + "' not found in vhost " + connection.getNamespaceName();

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpProtocolHandler.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpProtocolHandler.java
@@ -130,8 +130,8 @@ public class AmqpProtocolHandler implements ProtocolHandler {
         context.setContextPath("/api");
         context.setAttribute("aop", this);
 
-        Server jettyServer = new Server(port);
-        jettyServer.setHandler(context);
+        webServer = new Server(port);
+        webServer.setHandler(context);
 
         ServletHolder jerseyServlet = context.addServlet(ServletContainer.class, "/*");
         jerseyServlet.setInitOrder(0);
@@ -140,7 +140,7 @@ public class AmqpProtocolHandler implements ProtocolHandler {
                 "jersey.config.server.provider.packages", "io.streamnative.pulsar.handlers.amqp.admin");
 
         try {
-            jettyServer.start();
+            webServer.start();
         } catch (Exception e) {
             log.error("Failed to start web service for aop", e);
         }
@@ -180,7 +180,11 @@ public class AmqpProtocolHandler implements ProtocolHandler {
 
     @Override
     public void close() {
-        webServer.destroy();
+        try {
+            webServer.stop();
+        } catch (Exception e) {
+            log.error("Failed to stop web server for aop", e);
+        }
     }
 
     public static int getListenerPort(String listener) {

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpProtocolHandler.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpProtocolHandler.java
@@ -31,6 +31,10 @@ import org.apache.pulsar.broker.ServiceConfigurationUtils;
 import org.apache.pulsar.broker.protocol.ProtocolHandler;
 import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.policies.data.loadbalancer.AdvertisedListener;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
+import org.glassfish.jersey.servlet.ServletContainer;
 
 /**
  * Amqp Protocol Handler load and run by Pulsar Service.
@@ -50,8 +54,9 @@ public class AmqpProtocolHandler implements ProtocolHandler {
     private BrokerService brokerService;
     @Getter
     private String bindAddress;
-
+    @Getter
     private AmqpBrokerService amqpBrokerService;
+    private Server webServer;
 
     @Override
     public String protocolName() {
@@ -110,7 +115,7 @@ public class AmqpProtocolHandler implements ProtocolHandler {
                 log.error("Failed to start amqp proxy service.");
             }
         }
-
+        startAdminResource(amqpConfig.getAmqpAdminPort());
         log.info("Starting AmqpProtocolHandler, listener: {}, aop version is: '{}'",
                 getAppliedAmqpListeners(amqpConfig), AopVersion.getVersion());
         log.info("Git Revision {}", AopVersion.getGitSha());
@@ -118,6 +123,27 @@ public class AmqpProtocolHandler implements ProtocolHandler {
             AopVersion.getBuildUser(),
             AopVersion.getBuildHost(),
             AopVersion.getBuildTime());
+    }
+
+    private void startAdminResource(int port) {
+        ServletContextHandler context = new ServletContextHandler(ServletContextHandler.NO_SESSIONS);
+        context.setContextPath("/api");
+        context.setAttribute("aop", this);
+
+        Server jettyServer = new Server(port);
+        jettyServer.setHandler(context);
+
+        ServletHolder jerseyServlet = context.addServlet(ServletContainer.class, "/*");
+        jerseyServlet.setInitOrder(0);
+
+        jerseyServlet.setInitParameter(
+                "jersey.config.server.provider.packages", "io.streamnative.pulsar.handlers.amqp.admin");
+
+        try {
+            jettyServer.start();
+        } catch (Exception e) {
+            log.error("Failed to start web service for aop", e);
+        }
     }
 
     // this is called after initialize, and with amqpConfig, brokerService all set.
@@ -154,6 +180,7 @@ public class AmqpProtocolHandler implements ProtocolHandler {
 
     @Override
     public void close() {
+        webServer.destroy();
     }
 
     public static int getListenerPort(String listener) {

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpServiceConfiguration.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpServiceConfiguration.java
@@ -104,4 +104,5 @@ public class AmqpServiceConfiguration extends ServiceConfiguration {
             doc = "The aop admin service port"
     )
     private int amqpAdminPort = 15673;
+
 }

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpServiceConfiguration.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpServiceConfiguration.java
@@ -97,4 +97,11 @@ public class AmqpServiceConfiguration extends ServiceConfiguration {
             doc = "Whether start amqp protocol handler with proxy"
     )
     private boolean amqpProxyEnable = false;
+
+    @FieldContext(
+            category = CATEGORY_AMQP,
+            required = true,
+            doc = "The aop admin service port"
+    )
+    private int amqpAdminPort = 15673;
 }

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/ExchangeService.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/ExchangeService.java
@@ -14,7 +14,8 @@
 
 package io.streamnative.pulsar.handlers.amqp;
 
-import org.apache.qpid.server.protocol.v0_8.AMQShortString;
+import java.util.concurrent.CompletableFuture;
+import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.qpid.server.protocol.v0_8.FieldTable;
 
 /**
@@ -25,7 +26,6 @@ public interface ExchangeService {
     /**
      * Declare a exchange.
      *
-     * @param channel the channel used to do this action
      * @param exchange the name of the exchange
      * @param type the exchange type
      * @param passive Declare a queue exchange; i.e., check if it exists. In AMQP
@@ -34,30 +34,27 @@ public interface ExchangeService {
      * @param durable true if we are declaring a durable exchange (the exchange will survive a server restart)
      * @param autoDelete true if the server should delete the exchange when it is no longer in use
      * @param internal true if the exchange is internal, i.e. can't be directly published to by a client
-     * @param nowait set true will return nothing (as there will be no response from the server)
      * @param arguments other properties (construction arguments) for the exchange
      */
-    void exchangeDeclare(AmqpChannel channel, AMQShortString exchange, AMQShortString type, boolean passive,
-                         boolean durable, boolean autoDelete, boolean internal, boolean nowait, FieldTable arguments);
+    CompletableFuture<AmqpExchange> exchangeDeclare(NamespaceName namespaceName, String exchange, String type,
+                                                    boolean passive, boolean durable, boolean autoDelete,
+                                                    boolean internal, FieldTable arguments);
 
     /**
      * Delete a exchange.
      *
-     * @param channel the channel used to do this action
      * @param exchange the name of the exchange
      * @param ifUnused true to indicate that the exchange is only to be deleted if it is unused
-     * @param nowait set true will return nothing (as there will be no response from the server)
      */
-    void exchangeDelete(AmqpChannel channel, AMQShortString exchange, boolean ifUnused, boolean nowait);
+    CompletableFuture<Void> exchangeDelete(NamespaceName namespaceName, String exchange, boolean ifUnused);
 
     /**
      * Judge the exchange and the queue whether had bound.
      *
-     * @param channel the channel used to do this action
      * @param exchange the name of the exchange
      * @param routingKey the routing key to use for the binding
      * @param queueName the name of the queue
      */
-    void exchangeBound(AmqpChannel channel, AMQShortString exchange, AMQShortString routingKey,
-                       AMQShortString queueName);
+    CompletableFuture<Integer> exchangeBound(NamespaceName namespaceName, String exchange, String routingKey,
+                                          String queueName);
 }

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/QueueServiceImpl.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/QueueServiceImpl.java
@@ -14,6 +14,8 @@
 
 package io.streamnative.pulsar.handlers.amqp;
 
+import static io.streamnative.pulsar.handlers.amqp.utils.ExchangeUtil.getExchangeType;
+import static io.streamnative.pulsar.handlers.amqp.utils.ExchangeUtil.isBuildInExchange;
 import static org.apache.qpid.server.protocol.ErrorCodes.INTERNAL_ERROR;
 
 import java.util.Map;
@@ -242,9 +244,9 @@ public class QueueServiceImpl implements QueueService {
         }
         String exchangeType = null;
         boolean createIfMissing = false;
-        if (channel.isBuildInExchange(exchange)) {
+        if (isBuildInExchange(exchange.toString())) {
             createIfMissing = true;
-            exchangeType = channel.getExchangeType(exchange.toString());
+            exchangeType = getExchangeType(exchange.toString());
         }
 
         CompletableFuture<AmqpExchange> amqpExchangeCompletableFuture =

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/admin/Exchanges.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/admin/Exchanges.java
@@ -15,8 +15,6 @@ package io.streamnative.pulsar.handlers.amqp.admin;
 
 import io.streamnative.pulsar.handlers.amqp.admin.impl.ExchangeBase;
 import io.streamnative.pulsar.handlers.amqp.admin.model.ExchangeDeclareParams;
-import lombok.extern.slf4j.Slf4j;
-
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.PUT;
@@ -28,8 +26,11 @@ import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import lombok.extern.slf4j.Slf4j;
 
-
+/**
+ * Exchange endpoints.
+ */
 @Slf4j
 @Path("/exchanges")
 @Produces(MediaType.APPLICATION_JSON)
@@ -63,7 +64,7 @@ public class Exchanges extends ExchangeBase {
     @Path("/{vhost}/{exchange}")
     public void getExchange(@Suspended final AsyncResponse response,
                             @PathParam("vhost") String vhost,
-                            @PathParam("exchangeName") String exchange) {
+                            @PathParam("exchange") String exchange) {
         getExchangeBeanAsync(vhost, exchange)
                 .thenAccept(response::resume)
                 .exceptionally(t -> {

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/admin/Exchanges.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/admin/Exchanges.java
@@ -1,0 +1,112 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.amqp.admin;
+
+import io.streamnative.pulsar.handlers.amqp.admin.impl.ExchangeBase;
+import io.streamnative.pulsar.handlers.amqp.admin.model.ExchangeDeclareParams;
+import lombok.extern.slf4j.Slf4j;
+
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.container.AsyncResponse;
+import javax.ws.rs.container.Suspended;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+
+@Slf4j
+@Path("/exchanges")
+@Produces(MediaType.APPLICATION_JSON)
+public class Exchanges extends ExchangeBase {
+
+    @GET
+    public void getList(@Suspended final AsyncResponse response) {
+        getExchangeListAsync()
+                .thenAccept(response::resume)
+                .exceptionally(t -> {
+                    log.error("Failed to get exchange list for tenant {}", tenant, t);
+                    resumeAsyncResponseExceptionally(response, t);
+                    return null;
+                });
+    }
+
+    @GET
+    @Path("/{vhost}")
+    public void getListByVhost(@Suspended final AsyncResponse response,
+                               @PathParam("vhost") String vhost) {
+        getExchangeListByVhostAsync(vhost)
+                .thenAccept(response::resume)
+                .exceptionally(t -> {
+                    log.error("Failed to get exchange list by vhost {} for tenant {}", vhost, tenant, t);
+                    resumeAsyncResponseExceptionally(response, t);
+                    return null;
+                });
+    }
+
+    @GET
+    @Path("/{vhost}/{exchange}")
+    public void getExchange(@Suspended final AsyncResponse response,
+                            @PathParam("vhost") String vhost,
+                            @PathParam("exchangeName") String exchange) {
+        getExchangeBeanAsync(vhost, exchange)
+                .thenAccept(response::resume)
+                .exceptionally(t -> {
+                    log.error("Failed to get exchange {} for tenant {} belong to vhost {}",
+                            exchange, tenant, vhost, t);
+                    resumeAsyncResponseExceptionally(response, t);
+                    return null;
+                });
+    }
+
+    @PUT
+    @Path("/{vhost}/{exchange}")
+    public void declareExchange(@Suspended final AsyncResponse response,
+                                @PathParam("vhost") String vhost,
+                                @PathParam("exchange") String exchange,
+                                ExchangeDeclareParams params) {
+        declareExchange(vhost, exchange, params)
+                .thenAccept(__ -> response.resume(Response.noContent().build()))
+                .exceptionally(t -> {
+                    log.error("Failed to declare exchange {} for tenant {} belong to vhost {}",
+                            exchange, tenant, vhost, t);
+                    resumeAsyncResponseExceptionally(response, t);
+                    return null;
+                });
+    }
+
+    @DELETE
+    @Path("/{vhost}/{exchange}")
+    public void declareExchange(@Suspended final AsyncResponse response,
+                                @PathParam("vhost") String vhost,
+                                @PathParam("exchange") String exchange,
+                                @QueryParam("if-unused") boolean ifUnused) {
+        deleteExchange(vhost, exchange, ifUnused)
+                .thenAccept(__ -> {
+                    log.info("Success delete exchange {} in vhost {}, ifUnused is {}", exchange, vhost, ifUnused);
+                    response.resume(Response.noContent().build());
+                })
+                .exceptionally(t -> {
+                    log.error("Failed to delete exchange {} for tenant {} belong to vhost {}",
+                            exchange, tenant, vhost, t);
+                    resumeAsyncResponseExceptionally(response, t);
+                    return null;
+                });
+    }
+
+}

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/admin/Vhosts.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/admin/Vhosts.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.amqp.admin;
+
+import io.streamnative.pulsar.handlers.amqp.admin.impl.ExchangeBase;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.container.AsyncResponse;
+import javax.ws.rs.container.Suspended;
+import javax.ws.rs.core.MediaType;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Vhost endpoints.
+ */
+@Slf4j
+@Path("/vhosts")
+@Produces(MediaType.APPLICATION_JSON)
+public class Vhosts extends ExchangeBase {
+
+    @GET
+    public void getList(@Suspended final AsyncResponse response) {
+        getVhostListAsync()
+                .thenAccept(response::resume)
+                .exceptionally(t -> {
+                    log.error("Failed to get vhost list for tenant {}", tenant, t);
+                    resumeAsyncResponseExceptionally(response, t);
+                    return null;
+                });
+    }
+
+}

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/admin/impl/BaseResources.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/admin/impl/BaseResources.java
@@ -1,0 +1,93 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.amqp.admin.impl;
+
+import io.streamnative.pulsar.handlers.amqp.AmqpProtocolHandler;
+import io.streamnative.pulsar.handlers.amqp.ExchangeContainer;
+import io.streamnative.pulsar.handlers.amqp.ExchangeService;
+import org.apache.pulsar.broker.namespace.NamespaceService;
+import org.apache.pulsar.broker.resources.NamespaceResources;
+import org.apache.pulsar.broker.service.BrokerServiceException;
+import org.apache.pulsar.broker.web.RestException;
+import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.common.util.FutureUtil;
+
+import javax.servlet.ServletContext;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.container.AsyncResponse;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+
+public class BaseResources {
+
+    protected String tenant = "public";
+
+    @Context
+    protected ServletContext servletContext;
+
+    private AmqpProtocolHandler protocolHandler;
+
+    private NamespaceService namespaceService;
+
+    private NamespaceResources namespaceResources;
+
+    private ExchangeService exchangeService;
+
+    private ExchangeContainer exchangeContainer;
+
+    protected AmqpProtocolHandler aop() {
+        if (protocolHandler == null) {
+            protocolHandler = (AmqpProtocolHandler) servletContext.getAttribute("aop");
+        }
+        return protocolHandler;
+    }
+
+    protected NamespaceService namespaceService() {
+        if (namespaceService == null) {
+            namespaceService = aop().getBrokerService().getPulsar().getNamespaceService();
+        }
+        return namespaceService;
+    }
+
+    protected NamespaceResources namespaceResource() {
+        if (namespaceResources == null) {
+            namespaceResources = aop().getBrokerService().getPulsar().getPulsarResources().getNamespaceResources();
+        }
+        return namespaceResources;
+    }
+
+    protected ExchangeContainer exchangeContainer() {
+        if (exchangeContainer == null) {
+            exchangeContainer = aop().getAmqpBrokerService().getExchangeContainer();
+        }
+        return exchangeContainer;
+    }
+
+    protected ExchangeService exchangeService() {
+        if (exchangeService == null) {
+            exchangeService = aop().getAmqpBrokerService().getExchangeService();
+        }
+        return exchangeService;
+    }
+
+    protected static void resumeAsyncResponseExceptionally(AsyncResponse asyncResponse, Throwable exception) {
+        Throwable realCause = FutureUtil.unwrapCompletionException(exception);
+        if (realCause instanceof WebApplicationException) {
+            asyncResponse.resume(realCause);
+        } else {
+            asyncResponse.resume(new RestException(Response.Status.BAD_REQUEST, realCause.getMessage()));
+        }
+    }
+
+}

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/admin/impl/BaseResources.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/admin/impl/BaseResources.java
@@ -16,19 +16,23 @@ package io.streamnative.pulsar.handlers.amqp.admin.impl;
 import io.streamnative.pulsar.handlers.amqp.AmqpProtocolHandler;
 import io.streamnative.pulsar.handlers.amqp.ExchangeContainer;
 import io.streamnative.pulsar.handlers.amqp.ExchangeService;
-import org.apache.pulsar.broker.namespace.NamespaceService;
-import org.apache.pulsar.broker.resources.NamespaceResources;
-import org.apache.pulsar.broker.service.BrokerServiceException;
-import org.apache.pulsar.broker.web.RestException;
-import org.apache.pulsar.client.admin.PulsarAdminException;
-import org.apache.pulsar.common.util.FutureUtil;
-
+import io.streamnative.pulsar.handlers.amqp.admin.model.VhostBean;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import javax.servlet.ServletContext;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
+import org.apache.pulsar.broker.namespace.NamespaceService;
+import org.apache.pulsar.broker.resources.NamespaceResources;
+import org.apache.pulsar.broker.web.RestException;
+import org.apache.pulsar.common.util.FutureUtil;
 
+/**
+ * Base resources.
+ */
 public class BaseResources {
 
     protected String tenant = "public";
@@ -88,6 +92,19 @@ public class BaseResources {
         } else {
             asyncResponse.resume(new RestException(Response.Status.BAD_REQUEST, realCause.getMessage()));
         }
+    }
+
+    protected CompletableFuture<List<VhostBean>> getVhostListAsync() {
+        return namespaceResource().listNamespacesAsync(tenant)
+                .thenApply(nsList -> {
+                    List<VhostBean> vhostBeanList = new ArrayList<>();
+                    nsList.forEach(ns -> {
+                        VhostBean bean = new VhostBean();
+                        bean.setName(ns);
+                        vhostBeanList.add(bean);
+                    });
+                    return vhostBeanList;
+                });
     }
 
 }

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/admin/impl/ExchangeBase.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/admin/impl/ExchangeBase.java
@@ -16,18 +16,19 @@ package io.streamnative.pulsar.handlers.amqp.admin.impl;
 import io.streamnative.pulsar.handlers.amqp.AmqpExchange;
 import io.streamnative.pulsar.handlers.amqp.admin.model.ExchangeBean;
 import io.streamnative.pulsar.handlers.amqp.admin.model.ExchangeDeclareParams;
-import io.streamnative.pulsar.handlers.amqp.admin.model.VhostBean;
 import io.streamnative.pulsar.handlers.amqp.impl.PersistentExchange;
-import org.apache.pulsar.common.naming.NamespaceName;
-import org.apache.pulsar.common.naming.TopicName;
-import org.apache.pulsar.common.util.FutureUtil;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
+import org.apache.pulsar.common.naming.NamespaceName;
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.util.FutureUtil;
 
+/**
+ * Exchange base.
+ */
 public class ExchangeBase extends BaseResources {
 
     protected CompletableFuture<List<ExchangeBean>> getExchangeListAsync() {
@@ -40,19 +41,6 @@ public class ExchangeBase extends BaseResources {
                     }
                     return FutureUtil.waitForAll(futureList);
                 }).thenApply(__ -> exchangeList);
-    }
-
-    private CompletableFuture<List<VhostBean>> getVhostListAsync() {
-        return namespaceResource().listNamespacesAsync(tenant)
-                .thenApply(nsList -> {
-                    List<VhostBean> vhostBeanList = new ArrayList<>();
-                    nsList.forEach(ns -> {
-                        VhostBean bean = new VhostBean();
-                        bean.setName(ns);
-                        vhostBeanList.add(bean);
-                    });
-                    return vhostBeanList;
-                });
     }
 
     private CompletableFuture<List<String>> getExchangeListAsync(String tenant, String ns) {
@@ -82,6 +70,7 @@ public class ExchangeBase extends BaseResources {
             exchangeBean.setName(exchangeName);
             exchangeBean.setType(ex.getType().toString().toLowerCase());
             exchangeBean.setVhost(vhost);
+            exchangeBean.setAutoDelete(ex.getAutoDelete());
             exchangeBean.setInternal(false);
             return exchangeBean;
         });
@@ -89,8 +78,9 @@ public class ExchangeBase extends BaseResources {
 
     protected CompletableFuture<AmqpExchange> declareExchange(String vhost, String exchangeName,
                                                               ExchangeDeclareParams declareParams) {
-        return exchangeService().exchangeDeclare(NamespaceName.get(tenant, vhost), exchangeName, declareParams.getType(),
-                false, declareParams.isDurable(), declareParams.isAuto_delete(), declareParams.isInternal(), null);
+        return exchangeService().exchangeDeclare(NamespaceName.get(tenant, vhost), exchangeName,
+                declareParams.getType(), false, declareParams.isDurable(), declareParams.isAutoDelete(),
+                declareParams.isInternal(), null);
     }
 
     protected CompletableFuture<Void> deleteExchange(String vhost, String exchangeName, boolean ifUnused) {

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/admin/impl/ExchangeBase.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/admin/impl/ExchangeBase.java
@@ -1,0 +1,100 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.amqp.admin.impl;
+
+import io.streamnative.pulsar.handlers.amqp.AmqpExchange;
+import io.streamnative.pulsar.handlers.amqp.admin.model.ExchangeBean;
+import io.streamnative.pulsar.handlers.amqp.admin.model.ExchangeDeclareParams;
+import io.streamnative.pulsar.handlers.amqp.admin.model.VhostBean;
+import io.streamnative.pulsar.handlers.amqp.impl.PersistentExchange;
+import org.apache.pulsar.common.naming.NamespaceName;
+import org.apache.pulsar.common.naming.TopicName;
+import org.apache.pulsar.common.util.FutureUtil;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+public class ExchangeBase extends BaseResources {
+
+    protected CompletableFuture<List<ExchangeBean>> getExchangeListAsync() {
+        final List<ExchangeBean> exchangeList = new ArrayList<>();
+        return namespaceResource().listNamespacesAsync(tenant)
+                .thenCompose(nsList -> {
+                    Collection<CompletableFuture<Void>> futureList = new ArrayList<>();
+                    for (String ns : nsList) {
+                        futureList.add(getExchangeListByVhostAsync(ns).thenAccept(exchangeList::addAll));
+                    }
+                    return FutureUtil.waitForAll(futureList);
+                }).thenApply(__ -> exchangeList);
+    }
+
+    private CompletableFuture<List<VhostBean>> getVhostListAsync() {
+        return namespaceResource().listNamespacesAsync(tenant)
+                .thenApply(nsList -> {
+                    List<VhostBean> vhostBeanList = new ArrayList<>();
+                    nsList.forEach(ns -> {
+                        VhostBean bean = new VhostBean();
+                        bean.setName(ns);
+                        vhostBeanList.add(bean);
+                    });
+                    return vhostBeanList;
+                });
+    }
+
+    private CompletableFuture<List<String>> getExchangeListAsync(String tenant, String ns) {
+        return namespaceService()
+                .getFullListOfTopics(NamespaceName.get(tenant, ns))
+                .thenApply(list -> list.stream().filter(s ->
+                        s.contains(PersistentExchange.TOPIC_PREFIX)).collect(Collectors.toList()));
+    }
+
+    protected CompletableFuture<List<ExchangeBean>> getExchangeListByVhostAsync(String vhost) {
+        return getExchangeListAsync(tenant, vhost).thenCompose(exList -> {
+            Collection<CompletableFuture<Void>> futureList = new ArrayList<>();
+            List<ExchangeBean> beanList = new ArrayList<>();
+            exList.forEach(topic -> {
+                String exchangeName = TopicName.get(topic).getLocalName()
+                        .substring(PersistentExchange.TOPIC_PREFIX.length());
+                futureList.add(getExchangeBeanAsync(vhost, exchangeName).thenAccept(beanList::add));
+            });
+            return FutureUtil.waitForAll(futureList).thenApply(__ -> beanList);
+        });
+    }
+
+    protected CompletableFuture<ExchangeBean> getExchangeBeanAsync(String vhost, String exchangeName) {
+        return exchangeContainer().asyncGetExchange(
+                NamespaceName.get(tenant, vhost), exchangeName, false, null).thenApply(ex -> {
+            ExchangeBean exchangeBean = new ExchangeBean();
+            exchangeBean.setName(exchangeName);
+            exchangeBean.setType(ex.getType().toString().toLowerCase());
+            exchangeBean.setVhost(vhost);
+            exchangeBean.setInternal(false);
+            return exchangeBean;
+        });
+    }
+
+    protected CompletableFuture<AmqpExchange> declareExchange(String vhost, String exchangeName,
+                                                              ExchangeDeclareParams declareParams) {
+        return exchangeService().exchangeDeclare(NamespaceName.get(tenant, vhost), exchangeName, declareParams.getType(),
+                false, declareParams.isDurable(), declareParams.isAuto_delete(), declareParams.isInternal(), null);
+    }
+
+    protected CompletableFuture<Void> deleteExchange(String vhost, String exchangeName, boolean ifUnused) {
+        return exchangeService().exchangeDelete(NamespaceName.get(tenant, vhost), exchangeName, ifUnused);
+    }
+
+}

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/admin/impl/package-info.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/admin/impl/package-info.java
@@ -11,18 +11,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.streamnative.pulsar.handlers.amqp.admin.model;
-
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
 /**
- * This class is used to as return value of the vhost list admin api.
+ * Timer related classes.
+ *
+ * <p>The classes under this package are ported from Amqp.
  */
-@Data
-@NoArgsConstructor
-public class VhostBean {
-
-    private String name;
-
-}
+package io.streamnative.pulsar.handlers.amqp.admin.impl;

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/admin/model/ExchangeBean.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/admin/model/ExchangeBean.java
@@ -13,12 +13,14 @@
  */
 package io.streamnative.pulsar.handlers.amqp.admin.model;
 
-
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Map;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.util.Map;
-
+/**
+ * This class is used to as return value of the exchange list admin api.
+ */
 @Data
 @NoArgsConstructor
 public class ExchangeBean {
@@ -28,7 +30,8 @@ public class ExchangeBean {
     private String vhost;
     private boolean internal;
     private boolean durable;
-    private boolean auto_delete;
+    @JsonProperty("auto_delete")
+    private boolean autoDelete;
     private Map<String, Object> arguments;
 
 }

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/admin/model/ExchangeBean.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/admin/model/ExchangeBean.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.amqp.admin.model;
+
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Map;
+
+@Data
+@NoArgsConstructor
+public class ExchangeBean {
+
+    private String name;
+    private String type;
+    private String vhost;
+    private boolean internal;
+    private boolean durable;
+    private boolean auto_delete;
+    private Map<String, Object> arguments;
+
+}

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/admin/model/ExchangeDeclareParams.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/admin/model/ExchangeDeclareParams.java
@@ -1,0 +1,31 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.amqp.admin.model;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Map;
+
+@Data
+@NoArgsConstructor
+public class ExchangeDeclareParams {
+
+    private String type;
+    private boolean auto_delete;
+    private boolean durable;
+    private boolean internal;
+    private Map<String, Object> arguments;
+
+}

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/admin/model/ExchangeDeclareParams.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/admin/model/ExchangeDeclareParams.java
@@ -13,17 +13,21 @@
  */
 package io.streamnative.pulsar.handlers.amqp.admin.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Map;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.util.Map;
-
+/**
+ * This class is used to declare exchange params.
+ */
 @Data
 @NoArgsConstructor
 public class ExchangeDeclareParams {
 
     private String type;
-    private boolean auto_delete;
+    @JsonProperty(value = "auto_delete")
+    private boolean autoDelete;
     private boolean durable;
     private boolean internal;
     private Map<String, Object> arguments;

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/admin/model/VhostBean.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/admin/model/VhostBean.java
@@ -1,0 +1,25 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.amqp.admin.model;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class VhostBean {
+
+    private String name;
+
+}

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/admin/model/package-info.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/admin/model/package-info.java
@@ -11,18 +11,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.streamnative.pulsar.handlers.amqp.admin.model;
-
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
 /**
- * This class is used to as return value of the vhost list admin api.
+ * Timer related classes.
+ *
+ * <p>The classes under this package are ported from Amqp.
  */
-@Data
-@NoArgsConstructor
-public class VhostBean {
-
-    private String name;
-
-}
+package io.streamnative.pulsar.handlers.amqp.admin.model;

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/admin/package-info.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/admin/package-info.java
@@ -11,18 +11,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.streamnative.pulsar.handlers.amqp.admin.model;
-
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
 /**
- * This class is used to as return value of the vhost list admin api.
+ * Timer related classes.
+ *
+ * <p>The classes under this package are ported from Amqp.
  */
-@Data
-@NoArgsConstructor
-public class VhostBean {
-
-    private String name;
-
-}
+package io.streamnative.pulsar.handlers.amqp.admin;

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/common/exception/AoPException.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/common/exception/AoPException.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.amqp.common.exception;
+
+import lombok.Getter;
+
+public class AoPException extends RuntimeException {
+
+    @Getter
+    private final int errorCode;
+    @Getter
+    private final boolean closeChannel;
+    @Getter
+    private final boolean closeConnection;
+
+    public AoPException(int errorCode, String msg, boolean closeChannel, boolean closeConnection) {
+        super(msg);
+        this.errorCode = errorCode;
+        this.closeChannel = closeChannel;
+        this.closeConnection = closeConnection;
+    }
+
+}

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/utils/ExchangeUtil.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/utils/ExchangeUtil.java
@@ -1,0 +1,53 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.amqp.utils;
+
+import org.apache.qpid.server.exchange.ExchangeDefaults;
+import org.apache.qpid.server.protocol.v0_8.AMQShortString;
+
+public class ExchangeUtil {
+
+    public static boolean isBuildInExchange(final String exchangeName) {
+        return exchangeName.equals(ExchangeDefaults.DIRECT_EXCHANGE_NAME)
+                || (exchangeName.equals(ExchangeDefaults.FANOUT_EXCHANGE_NAME))
+                || (exchangeName.equals(ExchangeDefaults.TOPIC_EXCHANGE_NAME));
+    }
+
+    public static String getExchangeType(String exchangeName) {
+        if (null == exchangeName) {
+            exchangeName = "";
+        }
+        switch (exchangeName) {
+            case "":
+            case ExchangeDefaults.DIRECT_EXCHANGE_NAME:
+                return ExchangeDefaults.DIRECT_EXCHANGE_CLASS;
+            case ExchangeDefaults.FANOUT_EXCHANGE_NAME:
+                return ExchangeDefaults.FANOUT_EXCHANGE_CLASS;
+            case ExchangeDefaults.TOPIC_EXCHANGE_NAME:
+                return ExchangeDefaults.TOPIC_EXCHANGE_CLASS;
+            default:
+                return "";
+        }
+    }
+
+    public static String formatExchangeName(String s) {
+        return s.replaceAll("\r", "").
+                replaceAll("\n", "").trim();
+    }
+
+    public static boolean isDefaultExchange(final String exchangeName) {
+        return exchangeName == null || AMQShortString.EMPTY_STRING.toString().equals(exchangeName);
+    }
+
+}

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/utils/ExchangeUtil.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/utils/ExchangeUtil.java
@@ -25,10 +25,13 @@ public class ExchangeUtil {
     }
 
     public static String getExchangeType(String exchangeName) {
-        if (null == exchangeName) {
-            exchangeName = "";
+        String ex;
+        if (exchangeName == null) {
+            ex = "";
+        } else {
+            ex = exchangeName;
         }
-        switch (exchangeName) {
+        switch (ex) {
             case "":
             case ExchangeDefaults.DIRECT_EXCHANGE_NAME:
                 return ExchangeDefaults.DIRECT_EXCHANGE_CLASS;

--- a/tests/src/test/java/com/rabbitmq/client/test/HttpUtil.java
+++ b/tests/src/test/java/com/rabbitmq/client/test/HttpUtil.java
@@ -1,0 +1,98 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.rabbitmq.client.test;
+
+import java.io.IOException;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+
+/**
+ * HttpUtils.
+ */
+@Slf4j
+public class HttpUtil {
+
+    private static OkHttpClient client = new OkHttpClient();
+
+    private static final MediaType JSON = MediaType.get("application/json; charset=utf-8");
+
+    public static String get(String url) throws IOException {
+        Request.Builder builder = new Request.Builder()
+                .url(url)
+                .get();
+        Request request = builder.build();
+        try (Response response = client.newCall(request).execute()) {
+            String responseStr = response.body().string();
+            if (log.isDebugEnabled()) {
+                log.debug("get request ur: {} response: {}", url, responseStr);
+            }
+            return responseStr;
+        }
+    }
+
+    public static String put(String url, Map<String, Object> params) throws IOException {
+        RequestBody requestBody = RequestBody.create(JsonUtil.toString(params), JSON);
+
+        Request.Builder builder = new Request.Builder()
+                .url(url)
+                .put(requestBody);
+
+        Request request = builder.build();
+        try (Response response = client.newCall(request).execute()) {
+            String responseStr = response.body().string();
+            if (log.isDebugEnabled()) {
+                log.debug("put request ur: {} response: {}", url, responseStr);
+            }
+            return responseStr;
+        }
+    }
+
+    public static String post(String url, Map<String, Object> params) throws IOException {
+        RequestBody requestBody = RequestBody.create(JsonUtil.toString(params), JSON);
+
+        Request.Builder builder = new Request.Builder()
+                .url(url)
+                .post(requestBody);
+
+        Request request = builder.build();
+        try (Response response = client.newCall(request).execute()) {
+            String responseStr = response.body().string();
+            if (log.isDebugEnabled()) {
+                log.debug("post request ur: {} response: {}", url, responseStr);
+            }
+            return responseStr;
+        }
+    }
+
+    public static String delete(String url) throws IOException {
+        Request.Builder builder = new Request.Builder()
+                .url(url)
+                .delete();
+
+        Request request = builder.build();
+        try (Response response = client.newCall(request).execute()) {
+            String responseStr = response.body().string();
+            if (log.isDebugEnabled()) {
+                log.debug("delete request ur: {} response: {}", url, responseStr);
+            }
+            return responseStr;
+        }
+    }
+
+}

--- a/tests/src/test/java/com/rabbitmq/client/test/JsonUtil.java
+++ b/tests/src/test/java/com/rabbitmq/client/test/JsonUtil.java
@@ -1,0 +1,54 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.rabbitmq.client.test;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * JsonUtils.
+ */
+public class JsonUtil {
+
+    private static ObjectMapper objectMapper = new ObjectMapper();
+
+    public static String toString(Object object) throws JsonProcessingException {
+        return objectMapper.writeValueAsString(object);
+    }
+
+    public static <T> T parseObject(String jsonStr) throws IOException {
+        return objectMapper.readValue(jsonStr, new TypeReference<T>() {
+        });
+    }
+
+    public static <T> T parseObject(String jsonStr, Class<T> clazz) throws IOException {
+        return objectMapper.readValue(jsonStr, clazz);
+    }
+
+    public static <T> List<T> parseObjectList(String json, Class<T> obj) throws JsonProcessingException {
+        JavaType javaType = objectMapper.getTypeFactory().constructParametricType(ArrayList.class, obj);
+        return objectMapper.readValue(json, javaType);
+    }
+
+    public static JsonNode readTree(String jsonStr) throws IOException {
+        return objectMapper.readTree(jsonStr);
+    }
+
+}

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/AdminTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/AdminTest.java
@@ -16,41 +16,131 @@ package io.streamnative.pulsar.handlers.amqp;
 import com.rabbitmq.client.BuiltinExchangeType;
 import com.rabbitmq.client.Channel;
 import com.rabbitmq.client.Connection;
+import com.rabbitmq.client.test.HttpUtil;
+import com.rabbitmq.client.test.JsonUtil;
+import io.streamnative.pulsar.handlers.amqp.admin.model.ExchangeBean;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
+/**
+ * Admin API test.
+ */
 public class AdminTest extends AmqpTestBase{
 
-    @Test
-    public void test() throws Exception {
+    @Test(timeOut = 1000 * 30)
+    public void listTest() throws Exception {
         Connection connection = getConnection("vhost1", false);
         Channel channel = connection.createChannel();
-        channel.exchangeDeclare("ex1-1", BuiltinExchangeType.DIRECT, true);
-        channel.exchangeDeclare("ex1-2", BuiltinExchangeType.DIRECT, true);
-        channel.exchangeDeclare("ex1-3", BuiltinExchangeType.DIRECT, true);
+        Set<String> vhost1Queues = new HashSet<>();
+        for (int i = 0; i < 3; i++) {
+            String ex = randExName();
+            vhost1Queues.add(ex);
+            channel.exchangeDeclare(ex, BuiltinExchangeType.DIRECT, true);
+        }
+        String ex1 = vhost1Queues.iterator().next();
 
         Connection connection2 = getConnection("vhost2", false);
         Channel channel2 = connection2.createChannel();
-        channel2.exchangeDeclare("ex2-1", BuiltinExchangeType.DIRECT, true);
-        channel2.exchangeDeclare("ex2-2", BuiltinExchangeType.DIRECT, true);
-        channel2.exchangeDeclare("ex2-3", BuiltinExchangeType.DIRECT, true);
+        Set<String> vhost2Queues = new HashSet<>();
+        for (int i = 0; i < 3; i++) {
+            String ex = randExName();
+            vhost2Queues.add(ex);
+            channel2.exchangeDeclare(ex, BuiltinExchangeType.FANOUT, true);
+        }
 
-        System.out.println("aop server start");
-        Thread.sleep(1000 * 60 * 60);
+        List<ExchangeBean> exchangeBeans = exchangeList();
+        for (ExchangeBean bean : exchangeBeans) {
+            if (vhost1Queues.remove(bean.getName())) {
+                Assert.assertEquals(bean.getType(), "direct");
+            }
+            if (vhost2Queues.remove(bean.getName())) {
+                Assert.assertEquals(bean.getType(), "fanout");
+            }
+        }
+        Assert.assertEquals(vhost1Queues.size(), 0);
+        Assert.assertEquals(vhost2Queues.size(), 0);
+
+        List<ExchangeBean> exchangeBeans1 = exchangeListByVhost("vhost1");
+        Assert.assertTrue(exchangeBeans1.size() > 0);
+        for (ExchangeBean bean : exchangeBeans1) {
+            Assert.assertEquals(bean.getVhost(), "vhost1");
+        }
+
+        ExchangeBean bean = exchangeByName("vhost1", ex1);
+        Assert.assertEquals(bean.getName(), ex1);
     }
 
     @Test
-    public void test2() throws Exception {
-        Connection connection = getConnection("vhost1", 5672);
-        Channel channel = connection.createChannel();
-        channel.exchangeDeclare("ex1-1", BuiltinExchangeType.DIRECT, true);
-        channel.exchangeDeclare("ex1-2", BuiltinExchangeType.DIRECT, true);
-        channel.exchangeDeclare("ex1-3", BuiltinExchangeType.DIRECT, true);
+    public void declareAndDeleteTest() throws IOException {
+        String vhost = "vhost3";
+        String ex1 = randExName();
+        exchangeDeclare(vhost, ex1, BuiltinExchangeType.DIRECT.getType());
+        String ex2 = randExName();
+        exchangeDeclare(vhost, ex2, BuiltinExchangeType.TOPIC.getType());
+        String ex3 = randExName();
+        exchangeDeclare(vhost, ex3, BuiltinExchangeType.FANOUT.getType());
+        String ex4 = randExName();
+        exchangeDeclare(vhost, ex4, BuiltinExchangeType.HEADERS.getType());
 
-        Connection connection2 = getConnection("vhost2", 5672);
-        Channel channel2 = connection2.createChannel();
-        channel2.exchangeDeclare("ex2-1", BuiltinExchangeType.DIRECT, true);
-        channel2.exchangeDeclare("ex2-2", BuiltinExchangeType.DIRECT, true);
-        channel2.exchangeDeclare("ex2-3", BuiltinExchangeType.DIRECT, true);
+        List<ExchangeBean> beans = exchangeListByVhost(vhost);
+        Assert.assertEquals(beans.size(), 4);
+        for (ExchangeBean bean : beans) {
+            if (bean.getName().equals(ex1)) {
+                Assert.assertEquals(bean.getType(), BuiltinExchangeType.DIRECT.getType().toLowerCase());
+            } else if (bean.getName().equals(ex2)) {
+                Assert.assertEquals(bean.getType(), BuiltinExchangeType.TOPIC.getType().toLowerCase());
+            } else if (bean.getName().equals(ex3)) {
+                Assert.assertEquals(bean.getType(), BuiltinExchangeType.FANOUT.getType().toLowerCase());
+            } else if (bean.getName().equals(ex4)) {
+                Assert.assertEquals(bean.getType(), BuiltinExchangeType.HEADERS.getType().toLowerCase());
+            }
+        }
+
+        exchangeDelete(vhost, ex1);
+        exchangeDelete(vhost, ex2);
+        exchangeDelete(vhost, ex3);
+        beans = exchangeListByVhost(vhost);
+        Assert.assertEquals(beans.size(), 1);
+        Assert.assertEquals(beans.get(0).getName(), ex4);
+        exchangeDelete(vhost, ex4);
+    }
+
+    private void exchangeDeclare(String vhost, String exchange, String type) throws IOException {
+        Map<String, Object> declareParams = new HashMap<>();
+        declareParams.put("type", type);
+        declareParams.put("auto_delete", true);
+        declareParams.put("durable", true);
+        declareParams.put("internal", false);
+        HttpUtil.put(api("exchanges/" + vhost + "/" + exchange), declareParams);
+    }
+
+    private void exchangeDelete(String vhost, String exchange) throws IOException {
+        HttpUtil.delete(api("exchanges/" + vhost + "/" + exchange));
+    }
+
+    private List<ExchangeBean> exchangeList() throws IOException {
+        String exchangeJson = HttpUtil.get(api("exchanges"));
+        return JsonUtil.parseObjectList(exchangeJson, ExchangeBean.class);
+    }
+
+    private List<ExchangeBean> exchangeListByVhost(String vhost) throws IOException {
+        String exchangeJson = HttpUtil.get(api("exchanges/" + vhost));
+        return JsonUtil.parseObjectList(exchangeJson, ExchangeBean.class);
+    }
+
+    private ExchangeBean exchangeByName(String vhost, String exchange) throws IOException {
+        String exchangeJson = HttpUtil.get(api("exchanges/" + vhost + "/" + exchange));
+        return JsonUtil.parseObject(exchangeJson, ExchangeBean.class);
+    }
+
+    private String api(String path) {
+        return "http://localhost:" + new AmqpServiceConfiguration().getAmqpAdminPort() + "/api/" + path;
     }
 
 }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/AdminTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/AdminTest.java
@@ -1,0 +1,56 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.streamnative.pulsar.handlers.amqp;
+
+import com.rabbitmq.client.BuiltinExchangeType;
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Connection;
+import org.testng.annotations.Test;
+
+public class AdminTest extends AmqpTestBase{
+
+    @Test
+    public void test() throws Exception {
+        Connection connection = getConnection("vhost1", false);
+        Channel channel = connection.createChannel();
+        channel.exchangeDeclare("ex1-1", BuiltinExchangeType.DIRECT, true);
+        channel.exchangeDeclare("ex1-2", BuiltinExchangeType.DIRECT, true);
+        channel.exchangeDeclare("ex1-3", BuiltinExchangeType.DIRECT, true);
+
+        Connection connection2 = getConnection("vhost2", false);
+        Channel channel2 = connection2.createChannel();
+        channel2.exchangeDeclare("ex2-1", BuiltinExchangeType.DIRECT, true);
+        channel2.exchangeDeclare("ex2-2", BuiltinExchangeType.DIRECT, true);
+        channel2.exchangeDeclare("ex2-3", BuiltinExchangeType.DIRECT, true);
+
+        System.out.println("aop server start");
+        Thread.sleep(1000 * 60 * 60);
+    }
+
+    @Test
+    public void test2() throws Exception {
+        Connection connection = getConnection("vhost1", 5672);
+        Channel channel = connection.createChannel();
+        channel.exchangeDeclare("ex1-1", BuiltinExchangeType.DIRECT, true);
+        channel.exchangeDeclare("ex1-2", BuiltinExchangeType.DIRECT, true);
+        channel.exchangeDeclare("ex1-3", BuiltinExchangeType.DIRECT, true);
+
+        Connection connection2 = getConnection("vhost2", 5672);
+        Channel channel2 = connection2.createChannel();
+        channel2.exchangeDeclare("ex2-1", BuiltinExchangeType.DIRECT, true);
+        channel2.exchangeDeclare("ex2-2", BuiltinExchangeType.DIRECT, true);
+        channel2.exchangeDeclare("ex2-3", BuiltinExchangeType.DIRECT, true);
+    }
+
+}

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/AmqpTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/AmqpTestBase.java
@@ -88,15 +88,22 @@ public class AmqpTestBase extends AmqpProtocolHandlerTestBase {
     }
 
     protected Connection getConnection(String vhost, boolean amqpProxyEnable) throws IOException, TimeoutException {
+        int port;
+        if (amqpProxyEnable) {
+            port = getProxyPort();
+            log.info("use proxyPort: {}", port);
+            return getConnection(vhost, port);
+        } else {
+            port = getAmqpBrokerPortList().get(0);
+            log.info("use amqpBrokerPort: {}", port);
+        }
+        return getConnection(vhost, port);
+    }
+
+    protected Connection getConnection(String vhost, int port) throws IOException, TimeoutException {
         ConnectionFactory connectionFactory = new ConnectionFactory();
         connectionFactory.setHost("localhost");
-        if (amqpProxyEnable) {
-            int proxyPort = getProxyPort();
-            log.info("use proxyPort: {}", proxyPort);
-        } else {
-            connectionFactory.setPort(getAmqpBrokerPortList().get(0));
-            log.info("use amqpBrokerPort: {}", getAmqpBrokerPortList().get(0));
-        }
+        connectionFactory.setPort(port);
         connectionFactory.setVirtualHost(vhost);
         return connectionFactory.newConnection();
     }


### PR DESCRIPTION
### Motivation

Add exchange admin endpoints.

### Modifications

Support list, declare, delete exchange.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API: (yes / no)
  - The schema: (yes / no / don't know)
  - The default values of configurations: (yes / no)
  - The wire protocol: (yes / no)
  - The rest endpoints: (yes / no)
  - The admin cli options: (yes / no)
  - Anything that affects deployment: (yes / no / don't know)

### Documentation

Check the box below.

Need to update docs? 

- [x] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [ ] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)
