### PR TITLE
Support delete queue

### DIFF
--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/AdminTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/AdminTest.java
@@ -26,6 +26,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.apache.commons.collections.CollectionUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -159,7 +160,7 @@ public class AdminTest extends AmqpTestBase{
     }
 
     @Test(timeOut = 1000 * 5)
-    public void queueDeclareTest() throws IOException {
+    public void queueDeclareDeleteTest() throws IOException {
         String vhost = "vhost3";
         Set<String> queueNameSet = new HashSet<>();
         for (int i = 0; i < 3; i++) {
@@ -175,9 +176,16 @@ public class AdminTest extends AmqpTestBase{
         }
         Assert.assertEquals(queueNameSet.size(), 0);
 
-        String quName = randQuName();
-        queueDelete(vhost, quName);
-        queueDelete(vhost, quName);
+        String qu = beans.get(0).getName();
+        queueDelete(vhost, qu);
+        beans = listQueuesByVhost(vhost);
+        Assert.assertTrue(beans.size() > 0);
+        for (QueueBean bean : beans) {
+            Assert.assertNotEquals(bean.getName(), qu);
+            queueDelete(vhost, bean.getName());
+        }
+        beans = listQueuesByVhost(vhost);
+        Assert.assertTrue(CollectionUtils.isEmpty(beans));
     }
 
     private void exchangeDeclare(String vhost, String exchange, String type) throws IOException {


### PR DESCRIPTION
### Motivation

Support delete queue.

### Modifications

Delete all bindings of the queue.
Delete the pulsar topic of the queue.
Remove the queue from the cache.

### Verifying this change

Add new unit test

### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)
