### PR TITLE
[test] Set the broker shutdown timeout to 0

### DIFF
--- a/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/AopProtocolHandlerTestBase.java
+++ b/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/AopProtocolHandlerTestBase.java
@@ -75,6 +75,7 @@ public abstract class AopProtocolHandlerTestBase {
             "target/"
         );
         amqpServiceConfiguration.setMessagingProtocols(Sets.newHashSet("amqp"));
+        amqpServiceConfiguration.setBrokerShutdownTimeoutMs(0L);
         this.conf = amqpServiceConfiguration;
     }
 

--- a/tests-qpid-jms-client/src/test/java/io/streamnative/pulsar/handlers/amqp/AmqpProtocolHandlerTestBase.java
+++ b/tests-qpid-jms-client/src/test/java/io/streamnative/pulsar/handlers/amqp/AmqpProtocolHandlerTestBase.java
@@ -256,6 +256,7 @@ public abstract class AmqpProtocolHandlerTestBase {
             ((AmqpServiceConfiguration) conf).setAmqpProxyEnable(true);
             conf.setWebServicePort(Optional.of(brokerWebServicePort));
             conf.setWebServicePortTls(Optional.of(brokerWebServicePortTls));
+            conf.setBrokerShutdownTimeoutMs(0L);
 
             log.info("Start broker info [{}], brokerPort: {}, amqpBrokerPort: {}, aopProxyPort: {}",
                     i, brokerPort, amqpBrokerPort, aopProxyPort);

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/AmqpProtocolHandlerTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/AmqpProtocolHandlerTestBase.java
@@ -122,6 +122,7 @@ public abstract class AmqpProtocolHandlerTestBase {
         amqpConfig.setBrokerDeleteInactiveTopicsEnabled(false);
         amqpConfig.setBrokerEntryMetadataInterceptors(
                 Sets.newHashSet("org.apache.pulsar.common.intercept.AppendIndexMetadataInterceptor"));
+        amqpConfig.setBrokerShutdownTimeoutMs(0L);
 
         // set protocol related config
         URL testHandlerUrl = this.getClass().getClassLoader().getResource("test-protocol-handler.nar");
@@ -270,6 +271,7 @@ public abstract class AmqpProtocolHandlerTestBase {
             ((AmqpServiceConfiguration) conf).setAmqpProxyEnable(true);
             conf.setWebServicePort(Optional.of(brokerWebServicePort));
             conf.setWebServicePortTls(Optional.of(brokerWebServicePortTls));
+            conf.setBrokerShutdownTimeoutMs(0L);
 
             log.info("Start broker info [{}], brokerPort: {}, amqpBrokerPort: {}, aopProxyPort: {}",
                     i, brokerPort, amqpBrokerPort, aopProxyPort);


### PR DESCRIPTION
### Motivation

The graceful close operation of the pulsar service may increase test time and cause the test timeout.

### Modifications

Set the broker shutdown timeout to 0.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)
