### PR TITLE
Use the web service host name and AMQP port as the lookup result

### DIFF
--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/proxy/PulsarServiceLookupHandler.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/proxy/PulsarServiceLookupHandler.java
@@ -65,7 +65,7 @@ public class PulsarServiceLookupHandler implements LookupHandler, Closeable {
                         "Unable to resolve the broker for the topic: " + topicName));
                 return;
             }
-            String hostAndPort = result.getLeft().toString();
+            String hostAndPort = result.getLeft().getHostName() + ":" + result.getLeft().getPort();
 
             // fetch the protocol handler data
             List<LoadManagerReport> brokers = metadataStoreCacheLoader.getAvailableBrokers();
@@ -90,13 +90,15 @@ public class PulsarServiceLookupHandler implements LookupHandler, Closeable {
                 amqpBrokerAddress = AmqpProtocolHandler.PLAINTEXT_PREFIX + amqpBrokerAddress;
             }
             URI amqpBrokerUri;
+            URI webServiceUri;
             try {
                 amqpBrokerUri = new URI(amqpBrokerAddress);
+                webServiceUri = new URI(serviceLookupData.get().getWebServiceUrl());
             } catch (URISyntaxException e) {
                 lookupResult.completeExceptionally(e);
                 return;
             }
-            lookupResult.complete(Pair.of(amqpBrokerUri.getHost(), amqpBrokerUri.getPort()));
+            lookupResult.complete(Pair.of(webServiceUri.getHost(), amqpBrokerUri.getPort()));
         });
 
         return lookupResult;

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/RabbitMQMessagingTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/RabbitMQMessagingTest.java
@@ -107,10 +107,10 @@ public class RabbitMQMessagingTest extends AmqpTestBase {
                     Envelope envelope,
                     AMQP.BasicProperties properties,
                     byte[] body) throws IOException {
-                    waitForAtLeastOneDelivery.release();
                     long deliveryTag = envelope.getDeliveryTag();
-                    atomicInteger.incrementAndGet();
                     channel.basicNack(deliveryTag, false, true);
+                    waitForAtLeastOneDelivery.release();
+                    atomicInteger.incrementAndGet();
                 }
 
                 @Override


### PR DESCRIPTION
### Motivation

Currently, if users want to use the AoP in the Kubernetes environment, they couldn't set the `amqpListeners` and only use the port 5672, because if not specify the `amqpListeners` the proxy lookup result will use this hostname `InetAddress.getLocalHost().getCanonicalHostName()` and it could be resolved by other pods in k8s. Actually, because the AMQP doesn't support lookup operation, the AMQP service address will not be sent to clients, we can use the hostname of the web services directly.

### Modifications

Use the hostname of the web service and AMQP port as the lookup result.
Adjust test.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)
