### PR TITLE
Remove @streamnative/platform from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*                       @gaoran10 @codelipenghui @streamnative/platform
+*                       @gaoran10 @codelipenghui


### PR DESCRIPTION
Remove @streamnative/platform from CODEOWNERS  since the new PR will invite the CODEOWNERS as the reviewers. But the @streamnative/platform has a lot of engineers. Everyone under the @streamnative/platform will receive the Github notifications.