### PR TITLE
Fix - New add queue should not previously sent message.

### DIFF
--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/impl/PersistentExchange.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/impl/PersistentExchange.java
@@ -297,7 +297,7 @@ public class PersistentExchange extends AbstractAmqpExchange {
             if (log.isDebugEnabled()) {
                 log.debug("Create cursor {} for topic {}", name, persistentTopic.getName());
             }
-            ledger.asyncOpenCursor(name, CommandSubscribe.InitialPosition.Earliest,
+            ledger.asyncOpenCursor(name, CommandSubscribe.InitialPosition.Latest,
                     new AsyncCallbacks.OpenCursorCallback() {
                     @Override
                     public void openCursorComplete(ManagedCursor cursor, Object ctx) {


### PR DESCRIPTION
### Motivation

New add queue can only receive message that send after queue add to exchange.

### Modifications


### Verifying this change


### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
  
- [x] `no-need-doc`