### PR TITLE
Fix - Release netInputBuffer after connection closed

### DIFF
--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpBrokerDecoder.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpBrokerDecoder.java
@@ -91,6 +91,8 @@ public class AmqpBrokerDecoder extends ServerDecoder {
     }
 
     public void close() {
-        netInputBuffer = null;
+        if (netInputBuffer != null) {
+            netInputBuffer.close();
+        }
     }
 }

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/proxy/ProxyConnection.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/proxy/ProxyConnection.java
@@ -16,10 +16,10 @@ package io.streamnative.pulsar.handlers.amqp.proxy;
 import static com.google.common.base.Preconditions.checkState;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.nio.charset.StandardCharsets.UTF_8;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
 import io.streamnative.pulsar.handlers.amqp.AmqpBrokerDecoder;
@@ -121,40 +121,44 @@ public class ProxyConnection extends ChannelInboundHandlerAdapter implements
 
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
-        switch (state) {
-            case Init:
-            case RedirectLookup:
-                log.info("ProxyConnection [channelRead] - RedirectLookup");
-                connectMsgList.add(msg);
+        try {
+            switch (state) {
+                case Init:
+                case RedirectLookup:
+                    log.info("ProxyConnection [channelRead] - RedirectLookup");
+                    // Get a buffer that contains the full frame
+                    ByteBuf buffer = (ByteBuf) msg;
 
-                // Get a buffer that contains the full frame
-                ByteBuf buffer = (ByteBuf) msg;
+                    connectMsgList.add(QpidByteBuffer.wrap(buffer.nioBuffer()));
 
-                io.netty.channel.Channel nettyChannel = ctx.channel();
-                checkState(nettyChannel.equals(this.cnx.channel()));
+                    io.netty.channel.Channel nettyChannel = ctx.channel();
+                    checkState(nettyChannel.equals(this.cnx.channel()));
 
-                try {
-                    brokerDecoder.decodeBuffer(QpidByteBuffer.wrap(buffer.nioBuffer()));
-                } catch (Throwable e) {
-                    log.error("error while handle command:", e);
-                    close();
-                }
+                    try {
+                        brokerDecoder.decodeBuffer(QpidByteBuffer.wrap(buffer.nioBuffer()));
+                    } catch (Throwable e) {
+                        log.error("error while handle command:", e);
+                        close();
+                    }
 
-                break;
-            case RedirectToBroker:
-                if (log.isDebugEnabled()) {
-                    log.debug("ProxyConnection [channelRead] - RedirectToBroker");
-                }
-                if (proxyHandler != null) {
-                    proxyHandler.getBrokerChannel().writeAndFlush(msg);
-                }
-                break;
-            case Closed:
-                log.info("ProxyConnection [channelRead] - closed");
-                break;
-            default:
-                log.error("ProxyConnection [channelRead] - invalid state");
-                break;
+                    break;
+                case RedirectToBroker:
+                    if (log.isDebugEnabled()) {
+                        log.debug("ProxyConnection [channelRead] - RedirectToBroker");
+                    }
+                    if (proxyHandler != null) {
+                        proxyHandler.getBrokerChannel().writeAndFlush(msg);
+                    }
+                    break;
+                case Closed:
+                    log.info("ProxyConnection [channelRead] - closed");
+                    break;
+                default:
+                    log.error("ProxyConnection [channelRead] - invalid state");
+                    break;
+            }
+        } finally {
+            ReferenceCountUtil.safeRelease(msg);
         }
     }
 
@@ -377,6 +381,9 @@ public class ProxyConnection extends ChannelInboundHandlerAdapter implements
         }
         if (cnx != null) {
             cnx.close();
+        }
+        if (brokerDecoder != null) {
+            brokerDecoder.close();
         }
         state = State.Closed;
     }

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/proxy/ProxyConnection.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/proxy/ProxyConnection.java
@@ -378,6 +378,9 @@ public class ProxyConnection extends ChannelInboundHandlerAdapter implements
         if (cnx != null) {
             cnx.close();
         }
+        if (brokerDecoder != null) {
+            brokerDecoder.close();
+        }
         state = State.Closed;
     }
 

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/proxy/ProxyConnection.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/proxy/ProxyConnection.java
@@ -16,10 +16,10 @@ package io.streamnative.pulsar.handlers.amqp.proxy;
 import static com.google.common.base.Preconditions.checkState;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.nio.charset.StandardCharsets.UTF_8;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
-import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.FutureListener;
 import io.streamnative.pulsar.handlers.amqp.AmqpBrokerDecoder;
@@ -121,44 +121,40 @@ public class ProxyConnection extends ChannelInboundHandlerAdapter implements
 
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
-        try {
-            switch (state) {
-                case Init:
-                case RedirectLookup:
-                    log.info("ProxyConnection [channelRead] - RedirectLookup");
-                    // Get a buffer that contains the full frame
-                    ByteBuf buffer = (ByteBuf) msg;
+        switch (state) {
+            case Init:
+            case RedirectLookup:
+                log.info("ProxyConnection [channelRead] - RedirectLookup");
+                connectMsgList.add(msg);
 
-                    connectMsgList.add(QpidByteBuffer.wrap(buffer.nioBuffer()));
+                // Get a buffer that contains the full frame
+                ByteBuf buffer = (ByteBuf) msg;
 
-                    io.netty.channel.Channel nettyChannel = ctx.channel();
-                    checkState(nettyChannel.equals(this.cnx.channel()));
+                io.netty.channel.Channel nettyChannel = ctx.channel();
+                checkState(nettyChannel.equals(this.cnx.channel()));
 
-                    try {
-                        brokerDecoder.decodeBuffer(QpidByteBuffer.wrap(buffer.nioBuffer()));
-                    } catch (Throwable e) {
-                        log.error("error while handle command:", e);
-                        close();
-                    }
+                try {
+                    brokerDecoder.decodeBuffer(QpidByteBuffer.wrap(buffer.nioBuffer()));
+                } catch (Throwable e) {
+                    log.error("error while handle command:", e);
+                    close();
+                }
 
-                    break;
-                case RedirectToBroker:
-                    if (log.isDebugEnabled()) {
-                        log.debug("ProxyConnection [channelRead] - RedirectToBroker");
-                    }
-                    if (proxyHandler != null) {
-                        proxyHandler.getBrokerChannel().writeAndFlush(msg);
-                    }
-                    break;
-                case Closed:
-                    log.info("ProxyConnection [channelRead] - closed");
-                    break;
-                default:
-                    log.error("ProxyConnection [channelRead] - invalid state");
-                    break;
-            }
-        } finally {
-            ReferenceCountUtil.safeRelease(msg);
+                break;
+            case RedirectToBroker:
+                if (log.isDebugEnabled()) {
+                    log.debug("ProxyConnection [channelRead] - RedirectToBroker");
+                }
+                if (proxyHandler != null) {
+                    proxyHandler.getBrokerChannel().writeAndFlush(msg);
+                }
+                break;
+            case Closed:
+                log.info("ProxyConnection [channelRead] - closed");
+                break;
+            default:
+                log.error("ProxyConnection [channelRead] - invalid state");
+                break;
         }
     }
 
@@ -381,9 +377,6 @@ public class ProxyConnection extends ChannelInboundHandlerAdapter implements
         }
         if (cnx != null) {
             cnx.close();
-        }
-        if (brokerDecoder != null) {
-            brokerDecoder.close();
         }
         state = State.Closed;
     }

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/proxy/ProxyHandler.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/proxy/ProxyHandler.java
@@ -14,6 +14,7 @@
 package io.streamnative.pulsar.handlers.amqp.proxy;
 
 import static com.google.common.base.Preconditions.checkState;
+
 import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
@@ -121,6 +122,7 @@ public class ProxyHandler {
             this.cnx = ctx;
             super.channelActive(ctx);
             for (Object msg : connectMsgList) {
+                ((ByteBuf) msg).retain();
                 ctx.channel().writeAndFlush(msg).addListener(future -> {
                     ctx.channel().read();
                 });

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/proxy/ProxyHandler.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/proxy/ProxyHandler.java
@@ -14,7 +14,6 @@
 package io.streamnative.pulsar.handlers.amqp.proxy;
 
 import static com.google.common.base.Preconditions.checkState;
-
 import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
@@ -122,7 +121,6 @@ public class ProxyHandler {
             this.cnx = ctx;
             super.channelActive(ctx);
             for (Object msg : connectMsgList) {
-                ((ByteBuf) msg).retain();
                 ctx.channel().writeAndFlush(msg).addListener(future -> {
                     ctx.channel().read();
                 });


### PR DESCRIPTION
### Motivation

ByteBuf not released.

### Modifications


### Verifying this change


### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
  
- [x] `no-need-doc`