### PR TITLE
Fix - Add permit if receive nack command.

### DIFF
--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpChannel.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpChannel.java
@@ -17,7 +17,6 @@ import static io.streamnative.pulsar.handlers.amqp.utils.ExchangeUtil.getExchang
 import static io.streamnative.pulsar.handlers.amqp.utils.ExchangeUtil.isBuildInExchange;
 import static org.apache.qpid.server.protocol.ErrorCodes.INTERNAL_ERROR;
 import static org.apache.qpid.server.transport.util.Functions.hex;
-
 import com.google.common.annotations.VisibleForTesting;
 import io.streamnative.pulsar.handlers.amqp.common.exception.AoPException;
 import io.streamnative.pulsar.handlers.amqp.flow.AmqpFlowCreditManager;
@@ -755,6 +754,9 @@ public class AmqpChannel implements ServerChannelMethodProcessor {
         } else {
             closeChannel(ErrorCodes.IN_USE, "deliveryTag not found");
         }
+        ackedMessages.forEach(entry -> {
+            entry.getConsumer().handleFlow(1);
+        });
         if (creditManager.hasCredit() && isBlockedOnCredit()) {
             unBlockedOnCredit();
         }
@@ -767,6 +769,9 @@ public class AmqpChannel implements ServerChannelMethodProcessor {
         if (!ackedMessages.isEmpty()) {
             requeue(ackedMessages);
         }
+        ackedMessages.forEach(entry -> {
+            entry.getConsumer().handleFlow(1);
+        });
         if (creditManager.hasCredit() && isBlockedOnCredit()) {
             unBlockedOnCredit();
         }

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpPulsarConsumer.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpPulsarConsumer.java
@@ -113,6 +113,10 @@ public class AmqpPulsarConsumer implements UnacknowledgedMessageMap.MessageProce
         }
     }
 
+    @Override
+    public void handleFlow(int permits) {
+    }
+
     public void close() throws PulsarClientException {
         this.isClosed = true;
         this.consumer.pause();

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/UnacknowledgedMessageMap.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/UnacknowledgedMessageMap.java
@@ -36,6 +36,7 @@ public class UnacknowledgedMessageMap {
     public interface MessageProcessor {
         void messageAck(Position position);
         void requeue(List<PositionImpl> positions);
+        void handleFlow(int permits);
     }
 
     /**


### PR DESCRIPTION
### Motivation

Add permit if receive nack command.

The `availablePermits` will reduce when resend message to consumer. 

### Modifications


### Verifying this change


### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
  
- [x] `no-need-doc`