### PR TITLE
Fix - Support keep amqp message header's original type.

### DIFF
--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/MessageFetchContext.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/MessageFetchContext.java
@@ -26,6 +26,7 @@ import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.ManagedLedgerException;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.impl.PositionImpl;
+import org.apache.commons.codec.DecoderException;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.broker.service.persistent.PersistentSubscription;
 import org.apache.qpid.server.protocol.v0_8.transport.BasicGetEmptyBody;
@@ -110,7 +111,7 @@ public final class MessageFetchContext {
                                 try {
                                     message.complete(Pair.of(index.getPosition(),
                                             MessageConvertUtils.entryToAmqpBody(msg)));
-                                } catch (UnsupportedEncodingException e) {
+                                } catch (UnsupportedEncodingException | DecoderException e) {
                                     log.error("Failed to convert entry to AMQP body", e);
                                 }
                                 consumer.addUnAckMessages(indexMessage.getExchangeName(),

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/utils/MessageConvertUtils.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/utils/MessageConvertUtils.java
@@ -87,8 +87,7 @@ public final class MessageConvertUtils {
     private static final String PROP_IMMEDIATE = BASIC_PUBLISH_INFO_PRE + "immediate";
     private static final String PROP_MANDATORY = BASIC_PUBLISH_INFO_PRE + "mandatory";
     public static final String PROP_ROUTING_KEY = BASIC_PUBLISH_INFO_PRE + "routingKey";
-
-    public static final String AMQP_MESSAGE_HEADERS_PROPERTY_NAME = "__amqp__headers.property.name";
+    public static final String PROP_CUSTOM_PROPERTIES = BASIC_PROP_HEADER_PRE + "custom_properties";
 
     private static final Clock clock = Clock.systemDefaultZone();
 
@@ -137,7 +136,7 @@ public final class MessageConvertUtils {
             setProp(builder, PROP_PROPERTY_FLAGS, props.getPropertyFlags());
 
             byte[] headers = FieldTableFactory.createFieldTable(props.getHeadersAsMap()).getDataAsBytes();
-            builder.property(AMQP_MESSAGE_HEADERS_PROPERTY_NAME, Hex.encodeHexString(headers));
+            builder.property(PROP_CUSTOM_PROPERTIES, Hex.encodeHexString(headers));
         }
 
         setProp(builder, PROP_EXCHANGE, incomingMessage.getMessagePublishInfo().getExchange());
@@ -251,7 +250,7 @@ public final class MessageConvertUtils {
                 case PROP_ROUTING_KEY:
                     messagePublishInfo.setRoutingKey(AMQShortString.createAMQShortString(keyValue.getValue()));
                     break;
-                case AMQP_MESSAGE_HEADERS_PROPERTY_NAME:
+                case PROP_CUSTOM_PROPERTIES:
                     headers = setOriginalProperties(keyValue);
                     break;
                 default:

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/utils/MessageConvertUtils.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/utils/MessageConvertUtils.java
@@ -15,7 +15,6 @@ package io.streamnative.pulsar.handlers.amqp.utils;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
-
 import com.google.common.collect.ImmutableList;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
@@ -31,6 +30,8 @@ import java.util.concurrent.TimeUnit;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.Entry;
+import org.apache.commons.codec.DecoderException;
+import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.client.api.CompressionType;
 import org.apache.pulsar.client.api.Message;
@@ -45,6 +46,7 @@ import org.apache.pulsar.common.protocol.Commands;
 import org.apache.qpid.server.bytebuffer.QpidByteBuffer;
 import org.apache.qpid.server.bytebuffer.SingleQpidByteBuffer;
 import org.apache.qpid.server.protocol.v0_8.AMQShortString;
+import org.apache.qpid.server.protocol.v0_8.FieldTable;
 import org.apache.qpid.server.protocol.v0_8.FieldTableFactory;
 import org.apache.qpid.server.protocol.v0_8.IncomingMessage;
 import org.apache.qpid.server.protocol.v0_8.transport.BasicContentHeaderProperties;
@@ -85,6 +87,8 @@ public final class MessageConvertUtils {
     private static final String PROP_IMMEDIATE = BASIC_PUBLISH_INFO_PRE + "immediate";
     private static final String PROP_MANDATORY = BASIC_PUBLISH_INFO_PRE + "mandatory";
     public static final String PROP_ROUTING_KEY = BASIC_PUBLISH_INFO_PRE + "routingKey";
+
+    public static final String AMQP_MESSAGE_HEADERS_PROPERTY_NAME = "__amqp__headers.property.name";
 
     private static final Clock clock = Clock.systemDefaultZone();
 
@@ -132,10 +136,8 @@ public final class MessageConvertUtils {
             setProp(builder, PROP_CLUSTER_ID, props.getClusterIdAsString());
             setProp(builder, PROP_PROPERTY_FLAGS, props.getPropertyFlags());
 
-            Map<String, Object> headers = props.getHeadersAsMap();
-            for (Map.Entry<String, Object> entry : headers.entrySet()) {
-                setProp(builder, BASIC_PROP_HEADER_PRE + entry.getKey(), entry.getValue());
-            }
+            byte[] headers = FieldTableFactory.createFieldTable(props.getHeadersAsMap()).getDataAsBytes();
+            builder.property(AMQP_MESSAGE_HEADERS_PROPERTY_NAME, Hex.encodeHexString(headers));
         }
 
         setProp(builder, PROP_EXCHANGE, incomingMessage.getMessagePublishInfo().getExchange());
@@ -188,10 +190,10 @@ public final class MessageConvertUtils {
     }
 
     public static Pair<BasicContentHeaderProperties, MessagePublishInfo> getPropertiesFromMetadata(
-                                List<KeyValue> propertiesList) throws UnsupportedEncodingException {
+                                List<KeyValue> propertiesList) throws UnsupportedEncodingException, DecoderException {
         BasicContentHeaderProperties props = new BasicContentHeaderProperties();
-        Map<String, Object> headers = new HashMap<>();
         MessagePublishInfo messagePublishInfo = new MessagePublishInfo();
+        FieldTable headers = null;
 
         for (KeyValue keyValue : propertiesList) {
             switch (keyValue.getKey()) {
@@ -249,12 +251,26 @@ public final class MessageConvertUtils {
                 case PROP_ROUTING_KEY:
                     messagePublishInfo.setRoutingKey(AMQShortString.createAMQShortString(keyValue.getValue()));
                     break;
+                case AMQP_MESSAGE_HEADERS_PROPERTY_NAME:
+                    headers = setOriginalProperties(keyValue);
+                    break;
                 default:
-                    headers.put(keyValue.getKey().substring(BASIC_PROP_HEADER_PRE.length()), keyValue.getValue());
+                    log.warn("unknown property: {}, value: {}", keyValue.getKey(), keyValue.getValue());
+                    break;
             }
         }
-        props.setHeaders(FieldTableFactory.createFieldTable(headers));
+        props.setHeaders(headers);
         return Pair.of(props, messagePublishInfo);
+    }
+
+    private static FieldTable setOriginalProperties(KeyValue keyValue) throws DecoderException {
+        if (keyValue.getValue() == null) {
+            return null;
+        }
+        byte[] bytes = Hex.decodeHex(keyValue.getValue());
+        try (QpidByteBuffer buffer = QpidByteBuffer.wrap(bytes)) {
+            return FieldTableFactory.createFieldTable(buffer);
+        }
     }
 
     public static Pair<BasicContentHeaderProperties, MessagePublishInfo> getPropertiesFromMetadata(
@@ -328,7 +344,7 @@ public final class MessageConvertUtils {
     }
 
     public static List<AmqpMessageData> entriesToAmqpBodyList(List<Entry> entries)
-                                                                throws UnsupportedEncodingException {
+            throws UnsupportedEncodingException, DecoderException {
         ImmutableList.Builder<AmqpMessageData> builder = ImmutableList.builder();
         // TODO convert bk entries to amqpbody,
         //  then assemble deliver body with ContentHeaderBody and ContentBody
@@ -369,7 +385,7 @@ public final class MessageConvertUtils {
     }
 
     public static AmqpMessageData entryToAmqpBody(Entry entry)
-        throws UnsupportedEncodingException {
+        throws UnsupportedEncodingException, DecoderException {
         AmqpMessageData amqpMessage = null;
         // TODO convert bk entries to amqpbody,
         //  then assemble deliver body with ContentHeaderBody and ContentBody

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/utils/MessageConvertUtils.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/utils/MessageConvertUtils.java
@@ -15,6 +15,7 @@ package io.streamnative.pulsar.handlers.amqp.utils;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
+
 import com.google.common.collect.ImmutableList;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;

--- a/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/MessageConvertTest.java
+++ b/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/MessageConvertTest.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.bookkeeper.mledger.impl.EntryImpl;
+import org.apache.commons.codec.DecoderException;
 import org.apache.pulsar.client.impl.MessageImpl;
 import org.apache.qpid.server.bytebuffer.QpidByteBuffer;
 import org.apache.qpid.server.bytebuffer.SingleQpidByteBuffer;
@@ -46,7 +47,7 @@ import org.testng.annotations.Test;
 public class MessageConvertTest {
 
     @Test
-    private void test() throws UnsupportedEncodingException {
+    private void test() throws UnsupportedEncodingException, DecoderException {
         String exchange = "testExchange";
         boolean immediate = true;
         boolean mandatory = false;


### PR DESCRIPTION
### Motivation

Support keep amqp message header's original type.

In previous processing, all header field type will be formet to `String`.

### Modifications

Use hex to encode and decode all headers, so that client can get the original field and field type such as `FieldArray`.

### Verifying this change


### Does this pull request potentially affect one of the following parts:

*If `yes` was chosen, please highlight the changes*

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API: (no)
  - The schema: (no)
  - The default values of configurations: (no)
  - The wire protocol: (no)
  - The rest endpoints: (no)
  - The admin cli options: (no)
  - Anything that affects deployment: (no)

### Documentation

Check the box below and label this PR (if you have committer privilege).

Need to update docs? 
  
- [x] `no-need-doc`