### PR TITLE
[test] Ignore the jms1_1 test workflow

### DIFF
--- a/.github/workflows/pr-qpid-jms-test.yml
+++ b/.github/workflows/pr-qpid-jms-test.yml
@@ -1,72 +1,54 @@
-name: aop qpid-jms test
-
-on:
-  pull_request:
-    branches:
-      - master
-      - branch-*
-  push:
-    branches:
-      - master
-      - branch-*
-
-jobs:
-  build:
-
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v1
-
-    - name: Set up JDK 17
-      uses: actions/setup-java@v2
-      with:
-        distribution: 'temurin'
-        java-version: 17
-
-    - name: clean disk
-      if: steps.docs.outputs.changed_only == 'no'
-      run: |
-        df -h
-        sudo swapoff /swapfile
-        sudo rm -rf /swapfile /usr/share/dotnet /usr/local/lib/android /opt/ghc
-        sudo apt clean
-        docker rmi $(docker images -q) -f
-        df -h
-
-    - name: License check
-      run: mvn license:check
-
-    - name: Build with Maven skipTests
-      run: mvn clean install -DskipTests
-
-    - name: Style check
-      run: mvn checkstyle:check
-
-#    - name: Spotbugs check
-#      run: mvn spotbugs:check
-
-    - name: test jms_1_1
-      run: mvn test -DfailIfNoTests=false -pl tests-qpid-jms-client
-
-    - name: package surefire artifacts
-      if: failure()
-      uses: actions/upload-artifact@v3
-      with:
-        name: my-artifact
-        path: tests-qpid-jms-client/target/surefire-reports/ # or path/to/artifact
-
+#name: aop qpid-jms test
+#
+#on:
+#  pull_request:
+#    branches:
+#      - master
+#      - branch-*
+#  push:
+#    branches:
+#      - master
+#      - branch-*
+#
+#jobs:
+#  build:
+#
+#    runs-on: ubuntu-latest
+#
+#    steps:
+#    - uses: actions/checkout@v1
+#
+#    - name: Set up JDK 17
+#      uses: actions/setup-java@v2
+#      with:
+#        distribution: 'temurin'
+#        java-version: 17
+#
+#    - name: clean disk
+#      if: steps.docs.outputs.changed_only == 'no'
+#      run: |
+#        df -h
+#        sudo swapoff /swapfile
+#        sudo rm -rf /swapfile /usr/share/dotnet /usr/local/lib/android /opt/ghc
+#        sudo apt clean
+#        docker rmi $(docker images -q) -f
+#        df -h
+#
+#    - name: License check
+#      run: mvn license:check
+#
+#    - name: Build with Maven skipTests
+#      run: mvn clean install -DskipTests
+#
+#    - name: Style check
+#      run: mvn checkstyle:check
+#
+#    - name: test jms_1_1
+#      run: mvn test -DfailIfNoTests=false -pl tests-qpid-jms-client
+#
 #    - name: package surefire artifacts
 #      if: failure()
-#      run: |
-#        rm -rf artifacts
-#        mkdir artifacts
-#        find . -type d -name "*surefire-reports*" -exec cp --parents -R {} artifacts/ \;
-#        zip -r artifacts.zip artifacts
-
-#    - uses: actions/upload-artifact@master
-#      name: upload surefire-artifacts
-#      if: failure()
+#      uses: actions/upload-artifact@v3
 #      with:
-#        name: surefire-artifacts
-#        path: artifacts.zip
+#        name: my-artifact
+#        path: tests-qpid-jms-client/target/surefire-reports/ # or path/to/artifact


### PR DESCRIPTION
### Motivation

Currently, the jms1_1 test is not stable, and we can't provide a guarantee that AoP supports jms1_1, I think we can ignore the jms1_1 test workflow first.

After verifying the jms1_1 tests, we can reopen this workflow.

### Modifications

Ignore the jms1_1 test workflow.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)
