### PR TITLE
Add RabbitMQ amqp-client dependency for test

### DIFF
--- a/amqp-impl/pom.xml
+++ b/amqp-impl/pom.xml
@@ -54,6 +54,12 @@
       <version>${qpid-protocol-plugin.version}</version>
     </dependency>
 
+    <dependency>
+      <groupId>com.rabbitmq</groupId>
+      <artifactId>amqp-client</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>


### PR DESCRIPTION
### Motivation

Currently, the "com.rabbitmq:amqp-client" dependency is from bookkeeper-stats, we should dependent it directly.

```
+- io.streamnative:managed-ledger:jar:3.0.0.1-SNAPSHOT:provided
|  +- org.apache.bookkeeper.stats:prometheus-metrics-provider:jar:4.15.3:provided
|  |  +- org.apache.bookkeeper.stats:bookkeeper-stats-api:jar:4.15.3:provided
|  |  \- io.prometheus:simpleclient_servlet:jar:0.16.0:provided
|  |     +- io.prometheus:simpleclient_common:jar:0.16.0:provided
|  |     \- io.prometheus:simpleclient_servlet_common:jar:0.16.0:provided
|  +- org.apache.bookkeeper.stats:codahale-metrics-provider:jar:4.15.3:provided
|  |  +- io.dropwizard.metrics:metrics-jmx:jar:4.1.12.1:provided
|  |  +- io.dropwizard.metrics:metrics-jvm:jar:4.1.12.1:provided
|  |  \- io.dropwizard.metrics:metrics-graphite:jar:4.1.12.1:provided
|  |     \- com.rabbitmq:amqp-client:jar:5.8.0:provided
```

### Modifications

Add the "com.rabbitmq:amqp-client" dependency with test scope.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)
