### PR TITLE
[fix] Release `EntryImpl` while reading exchange topic

### DIFF
--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpExchangeReplicator.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpExchangeReplicator.java
@@ -35,10 +35,10 @@ import org.apache.bookkeeper.mledger.Position;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
-import org.apache.pulsar.client.impl.Backoff;
 import org.apache.pulsar.client.impl.MessageImpl;
 import org.apache.pulsar.common.api.proto.CommandSubscribe;
 import org.apache.pulsar.common.api.proto.KeyValue;
+import org.apache.pulsar.common.util.Backoff;
 
 /**
  * Amqp exchange replicator, read entries from BookKeeper and process entries.

--- a/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpPulsarConsumer.java
+++ b/amqp-impl/src/main/java/io/streamnative/pulsar/handlers/amqp/AmqpPulsarConsumer.java
@@ -23,9 +23,9 @@ import org.apache.bookkeeper.mledger.impl.PositionImpl;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.PulsarClientException;
-import org.apache.pulsar.client.impl.Backoff;
-import org.apache.pulsar.client.impl.BackoffBuilder;
 import org.apache.pulsar.client.impl.MessageIdImpl;
+import org.apache.pulsar.common.util.Backoff;
+import org.apache.pulsar.common.util.BackoffBuilder;
 import org.apache.qpid.server.protocol.v0_8.AMQShortString;
 
 /**

--- a/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/AmqpProtocolTestBase.java
+++ b/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/AmqpProtocolTestBase.java
@@ -148,6 +148,7 @@ public abstract class AmqpProtocolTestBase {
             }
         });
         when(pulsarService.getConfiguration()).thenReturn(serviceConfiguration);
+        when(pulsarService.getConfig()).thenReturn(serviceConfiguration);
         when(pulsarService.getOrderedExecutor()).thenReturn(
                 OrderedExecutor.newBuilder().numThreads(8).name("pulsar-ordered").build());
         when(serviceConfiguration.getNumIOThreads()).thenReturn(2 * Runtime.getRuntime().availableProcessors());

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/AmqpProtocolHandlerTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/AmqpProtocolHandlerTestBase.java
@@ -102,6 +102,8 @@ public abstract class AmqpProtocolHandlerTestBase {
     @Getter
     private List<Integer> aopAdminPortList = new ArrayList<>();
 
+    private final Integer inFlightSizeInMB = 5;
+
     public AmqpProtocolHandlerTestBase() {
         resetConfig();
     }
@@ -128,6 +130,7 @@ public abstract class AmqpProtocolHandlerTestBase {
         amqpConfig.setBrokerShutdownTimeoutMs(0L);
         amqpConfig.setDefaultNumPartitions(1);
         amqpConfig.setTransactionCoordinatorEnabled(true);
+        amqpConfig.setManagedLedgerMaxReadsInFlightSizeInMB(inFlightSizeInMB);
 
         // set protocol related config
         URL testHandlerUrl = this.getClass().getClassLoader().getResource("test-protocol-handler.nar");

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/AmqpTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/AmqpTestBase.java
@@ -28,6 +28,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicDomain;
 import org.apache.pulsar.common.naming.TopicName;
@@ -162,6 +163,10 @@ public class AmqpTestBase extends AmqpProtocolHandlerTestBase {
                 .until(messageSet::isEmpty);
         channel.close();
         conn.close();
+
+        for (PulsarService pulsarService : getPulsarServiceList()) {
+
+        }
     }
 
 }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/AmqpTestBase.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/AmqpTestBase.java
@@ -28,7 +28,6 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.pulsar.broker.PulsarService;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicDomain;
 import org.apache.pulsar.common.naming.TopicName;
@@ -163,10 +162,6 @@ public class AmqpTestBase extends AmqpProtocolHandlerTestBase {
                 .until(messageSet::isEmpty);
         channel.close();
         conn.close();
-
-        for (PulsarService pulsarService : getPulsarServiceList()) {
-
-        }
     }
 
 }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/RabbitMQMessagingTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/RabbitMQMessagingTest.java
@@ -517,7 +517,7 @@ public class RabbitMQMessagingTest extends AmqpTestBase {
         conn.close();
     }
 
-    @Test
+    @Test(timeOut = 15_000)
     public void testConsumeMoreThanInFlightSize() throws Exception {
         Connection conn = getConnection("vhost1", true);
         Channel channel = conn.createChannel();
@@ -548,7 +548,7 @@ public class RabbitMQMessagingTest extends AmqpTestBase {
         } while (sendContentSize.addAndGet(content.length) < totalContentSize);
 
 
-        assertTrue(latch.await(30, TimeUnit.SECONDS));
+        assertTrue(latch.await(10, TimeUnit.SECONDS));
         channel.close();
         conn.close();
     }

--- a/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/RabbitMQMessagingTest.java
+++ b/tests/src/test/java/io/streamnative/pulsar/handlers/amqp/rabbitmq/RabbitMQMessagingTest.java
@@ -533,7 +533,6 @@ public class RabbitMQMessagingTest extends AmqpTestBase {
             @Override
             public void handleDelivery(String consumerTag, Envelope envelope, AMQP.BasicProperties properties,
                                        byte[] body) throws IOException {
-                System.out.println("receive msg");
                 if (receiveContentSize.addAndGet(body.length) >= totalContentSize) {
                     latch.countDown();
                 }
@@ -544,9 +543,7 @@ public class RabbitMQMessagingTest extends AmqpTestBase {
         byte[] content = RandomUtils.nextBytes(1024 * 100);
         do {
             channel.basicPublish("", qu, null, content);
-            System.out.println("send message");
         } while (sendContentSize.addAndGet(content.length) < totalContentSize);
-
 
         assertTrue(latch.await(10, TimeUnit.SECONDS));
         channel.close();


### PR DESCRIPTION
### Motivation

The [PR](https://github.com/apache/pulsar/pull/18245) introduced the InflightReadsLimiter, the exchange replicator will read data and route index data to the queue topic, but it doesn't release the EntryImpl object, this will cause the broker in-flight read cache limiter to be exhausted.

### Modifications

Release `EntryImpl` object while reading the exchange topic.
Use topic dispatch limiter to control read batch size.

### Verifying this change

Add test to verify the in-flight read cache can't be exhausted.

### Does this pull request potentially affect one of the following parts:

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)
