### PR TITLE
Fix SN bom version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
       <dependency>
         <groupId>io.streamnative</groupId>
         <artifactId>streamnative-bom</artifactId>
-        <version>4.1.0-SNAPSHOT</version>
+        <version>${sn.bom.version}</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>


### PR DESCRIPTION
### Motivation

We should use `${sn.bom.version}` for the sn-bom version. Otherwise it would block the release.
