### PR TITLE
Use Github package wildcard repository url

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -341,7 +341,7 @@
     </repository>
     <repository>
       <id>github</id>
-      <url>https://maven.pkg.github.com/streamnative/streamnative-bom</url>
+      <url>https://maven.pkg.github.com/streamnative/*</url>
       <snapshots>
         <enabled>true</enabled>
       </snapshots>

--- a/pom.xml
+++ b/pom.xml
@@ -336,10 +336,6 @@
       <url>https://repo1.maven.org/maven2</url>
     </repository>
     <repository>
-      <id>nexus-snapshot-repo</id>
-      <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
-    </repository>
-    <repository>
       <id>github</id>
       <url>https://maven.pkg.github.com/streamnative/*</url>
       <snapshots>


### PR DESCRIPTION
We will use github private maven repository widely in the future including streamnative/pulsar's.

It is convenient to use wildcard repository url to match all the maven packages of SN org.