### PR TITLE
[fix][test] Fix configuration potential NPE in test

### DIFF
--- a/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/AmqpProtocolTestBase.java
+++ b/amqp-impl/src/test/java/io/streamnative/pulsar/handlers/amqp/test/AmqpProtocolTestBase.java
@@ -138,7 +138,7 @@ public abstract class AmqpProtocolTestBase {
         pulsarService = mock(PulsarService.class);
         PulsarAdmin adminClient = mock(PulsarAdmin.class);
         Namespaces namespaces = mock(Namespaces.class);
-        ServiceConfiguration serviceConfiguration = mock(ServiceConfiguration.class);
+        ServiceConfiguration serviceConfiguration = spy(new ServiceConfiguration());
         when(pulsarService.getAdminClient()).thenReturn(adminClient);
         when(pulsarService.getAdminClient().namespaces()).thenReturn(namespaces);
         when(pulsarService.getBrokerService()).then(new Answer<Object>() {


### PR DESCRIPTION
### Motivation

Fix configuration potential NPE in test.

### Modifications

Use a spy configuration object instead of a mock configuration object.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)
